### PR TITLE
(chore)chart_versions: update litmus helm chart to 1.2.2 release

### DIFF
--- a/charts/litmus/Chart.yaml
+++ b/charts/litmus/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.2.0"
+appVersion: "1.2.2"
 description: A Helm chart to install litmus infra components on Kubernetes
 name: litmus
-version: 1.2.0
+version: 1.2.2

--- a/charts/litmus/templates/deployment.yaml
+++ b/charts/litmus/templates/deployment.yaml
@@ -20,13 +20,17 @@ spec:
       serviceAccountName: {{ include "litmus.fullname" . }} 
       containers:
         - name: {{ .Values.operatorName }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.operator.repository }}:{{ .Values.image.operator.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: 
           - chaos-operator
           env:
+            - name: CHAOS_RUNNER_IMAGE
+              value: "{{ .Values.image.runner.repository }}:{{ .Values.image.runner.tag }}"
+            - name: CHAOS_MONITOR_IMAGE
+              value: "{{ .Values.image.exporter.repository }}:{{ .Values.image.exporter.tag }}"
             - name: WATCH_NAMESPACE
-              value: 
+              value:  
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/charts/litmus/values.yaml
+++ b/charts/litmus/values.yaml
@@ -10,9 +10,18 @@ operatorName: "chaos-operator"
 replicaCount: 1
 
 image:
-  repository: litmuschaos/chaos-operator
-  tag: 1.2.0 
-  pullPolicy: Always
+  operator: 
+    repository: litmuschaos/chaos-operator
+    tag: 1.2.2 
+    pullPolicy: Always
+  runner:
+    repository: litmuschaos/chaos-runner
+    tag: 1.2.2 
+    pullPolicy: Always
+  exporter:
+    repository: litmuschaos/chaos-exporter
+    tag: 1.2.2 
+    pullPolicy: Always
 
 service:
   type: ClusterIP


### PR DESCRIPTION
- Updates deploy specs and adds runner, exporter specs to values.yaml
- Updates image and chart versions to 1.2.2

Signed-off-by: ksatchit <karthik.s@mayadata.io>