### PR TITLE
(fix)charts: remove chart labels from selector list

### DIFF
--- a/charts/litmus/templates/deployment.yaml
+++ b/charts/litmus/templates/deployment.yaml
@@ -3,19 +3,20 @@ kind: Deployment
 metadata:
   name: {{ include "litmus.fullname" . }} 
   labels:
+    name: {{ include "litmus.name" . }}
+    chart: {{ include "litmus.chart" . }}
+    instance: {{ .Release.Name }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "litmus.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/chart: {{ include "litmus.chart" . }}
+      name: {{ include "litmus.name" . }}
+      instance: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "litmus.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/chart: {{ include "litmus.chart" . }}
+        name: {{ include "litmus.name" . }}
+        instance: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ include "litmus.fullname" . }} 
       containers:


### PR DESCRIPTION
- This PR removes the `chart` label from selectors in the operator deployment template. Keeping the chart label in the selector list will cause a failure during helm upgrades (where the chart version change will result in essentially a different label value, in turn causing patch failures) -- the selectors are supposed to be immutable.

- Also updates the label keys to be shorter and simpler.

Signed-off-by: ksatchit <karthik.s@mayadata.io>