### PR TITLE
Add opportunity to enable or disable google analytics in chaos operator

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,8 @@
 <!--
-Thank you for contributing to helm/charts. Before you submit this PR we'd like to
-make sure you are aware of our technical requirements and best practices:
 
 * https://github.com/helm/helm/tree/master/docs/chart_best_practices
 
-Following our best practices right from the start will accelerate the review process and
+Following best practices right from the start will accelerate the review process and
 help get your PR merged quicker.
 
 When updates to your PR are requested, please add new commits and do not squash the
@@ -29,6 +27,6 @@ even continue reviewing your changes.
 
 #### Checklist
 [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
-- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
+- [ ] DCO signed
 - [ ] Chart Version bumped
 - [ ] Variables are documented in the README.md

--- a/charts/litmus/Chart.yaml
+++ b/charts/litmus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.3.0"
 description: A Helm chart to install litmus infra components on Kubernetes
 name: litmus
-version: 1.3.3
+version: 1.3.4
 home: https://litmuschaos.io
 sources:
   - https://github.com/litmuschaos/litmus

--- a/charts/litmus/README.md
+++ b/charts/litmus/README.md
@@ -2,7 +2,7 @@ litmus
 ======
 A Helm chart to install litmus infra components on Kubernetes.
 
-Current chart version is `1.3.3`
+Current chart version is `1.3.4`
 
 ## Architecture introduction
 
@@ -67,6 +67,7 @@ The following table lists the configurable parameters of the Litmus chart and th
 | operatorName | string | `"chaos-operator"` | Operator name |
 | replicaCount | int | `1` | Replica count |
 | resources | object | `{}` | Resources requests and limits |
+| policies.monitoring.disabled | string | false | If google analytics disabled |
 | service.port | int | `80` | Service port |
 | service.type | string | `"ClusterIP"` | Service type |
 | tolerations | list | `[]` | Tolerations |

--- a/charts/litmus/templates/deployment.yaml
+++ b/charts/litmus/templates/deployment.yaml
@@ -36,6 +36,10 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "chaos-operator"
+          {{- if .Values.policies.monitoring.disabled }}
+            - name: ANALYTICS
+              value: "FALSE"
+          {{- end }}
           ports:
             - name: http
               containerPort: 80

--- a/charts/litmus/values.yaml
+++ b/charts/litmus/values.yaml
@@ -60,6 +60,12 @@ affinity: {}
 administratorMode:
   enabled: false
 
+# Support for disabling google analytics
+# https://docs.litmuschaos.io/docs/faq-general/#does-litmus-track-any-usage-metrics-on-the-test-clusters
+policies:
+  monitoring:
+    disabled: true
+
 exporter:
   enabled: false
   serviceMonitor:

--- a/charts/litmus/values.yaml
+++ b/charts/litmus/values.yaml
@@ -64,7 +64,7 @@ administratorMode:
 # https://docs.litmuschaos.io/docs/faq-general/#does-litmus-track-any-usage-metrics-on-the-test-clusters
 policies:
   monitoring:
-    disabled: true
+    disabled: false
 
 exporter:
   enabled: false


### PR DESCRIPTION
Signed-off-by: Jasstkn <jasssstkn@yahoo.com>

#### What this PR does / why we need it:
Add support for disabling google analytics in chaos operator, because it could be a security issue for using litmus.

#### Which issue this PR fixes
- fixes #18 

#### Special notes for your reviewer:

#### Checklist
- [x] DCO signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md