### PR TITLE
Update chart with 1.5.1 version of litmus

### DIFF
--- a/charts/litmus/Chart.yaml
+++ b/charts/litmus/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.5.0"
+appVersion: "1.5.1"
 description: A Helm chart to install litmus infra components on Kubernetes
 name: litmus
-version: 1.5.0
+version: 1.5.1
 home: https://litmuschaos.io
 sources:
   - https://github.com/litmuschaos/litmus

--- a/charts/litmus/README.md
+++ b/charts/litmus/README.md
@@ -2,7 +2,7 @@ litmus
 ======
 A Helm chart to install litmus infra components on Kubernetes.
 
-Current chart version is `1.3.4`
+Current chart version is `1.5.1`
 
 ## Architecture introduction
 
@@ -59,7 +59,7 @@ The following table lists the configurable parameters of the Litmus chart and th
 | fullnameOverride | string | `"litmus"` | Full name override |
 | operator.image.pullPolicy | string | `"Always"` | Image operator or runner pull policy |
 | \<operator\|runner\>.image.repository | string | `"litmuschaos/chaos-operator"` | Image operator or runner repository |
-| \<operator\|runner\>.image.tag | string | `"1.5.0"` | Image operator or runner tag |
+| \<operator\|runner\>.image.tag | string | `"1.5.1"` | Image operator or runner tag |
 | ingress.annotations | object | `{}` | Ingress annotations |
 | ingress.enabled | bool | `false` | Ingress enabled |
 | nameOverride | string | `"litmus"` | Name override |

--- a/charts/litmus/values.yaml
+++ b/charts/litmus/values.yaml
@@ -12,12 +12,12 @@ replicaCount: 1
 operator:
   image:
     repository: litmuschaos/chaos-operator
-    tag: 1.5.0
+    tag: 1.5.1
     pullPolicy: Always
 runner:
   image:
     repository: litmuschaos/chaos-runner
-    tag: 1.5.0
+    tag: 1.5.1
 
 service:
   type: ClusterIP


### PR DESCRIPTION
Signed-off-by: Jasstkn <jasssstkn@yahoo.com>

<!--

* https://github.com/helm/helm/tree/master/docs/chart_best_practices

Following best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
- update docker tag of chaos-operator & chaos-runner to 1.5.1

#### Checklist
- [x] DCO signed
- [x] Chart Version bumped