### PR TITLE
(fix)role: add replicaset permissions for operator

### DIFF
--- a/charts/litmus/Chart.yaml
+++ b/charts/litmus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.6.2"
 description: A Helm chart to install litmus infra components on Kubernetes
 name: litmus
-version: 1.6.3
+version: 1.6.4
 home: https://litmuschaos.io
 sources:
   - https://github.com/litmuschaos/litmus

--- a/charts/litmus/templates/clusterrole.yaml
+++ b/charts/litmus/templates/clusterrole.yaml
@@ -11,7 +11,7 @@ metadata:
     litmuschaos.io/version: {{ .Chart.AppVersion }}
 rules:
 - apiGroups: ["","apps","batch","litmuschaos.io"]
-  resources: ["pods","jobs","deployments","daemonsets","statefulsets","events","configmaps","services","chaosengines","chaosexperiments","chaosresults"]
+  resources: ["pods","jobs","deployments","replicasets","daemonsets","statefulsets","events","configmaps","services","chaosengines","chaosexperiments","chaosresults"]
   verbs: ["get","create","update","patch","delete","list","watch","deletecollection"]
 {{ end }} 
 {{ if eq .Values.operatorMode "admin" }}

--- a/charts/litmus/templates/clusterrole.yaml
+++ b/charts/litmus/templates/clusterrole.yaml
@@ -10,8 +10,8 @@ metadata:
     chart: {{ include "litmus.chart" . }}
     litmuschaos.io/version: {{ .Chart.AppVersion }}
 rules:
-- apiGroups: ["","apps","batch","litmuschaos.io"]
-  resources: ["pods","jobs","deployments","replicasets","daemonsets","statefulsets","events","configmaps","services","chaosengines","chaosexperiments","chaosresults"]
+- apiGroups: ["","apps","batch","litmuschaos.io","apps.openshift.io"]
+  resources: ["pods","jobs","deployments","replicasets","replicationcontrollers","deploymentconfigs","daemonsets","statefulsets","events","configmaps","services","chaosengines","chaosexperiments","chaosresults"]
   verbs: ["get","create","update","patch","delete","list","watch","deletecollection"]
 {{ end }} 
 {{ if eq .Values.operatorMode "admin" }}

--- a/charts/litmus/templates/namespaced-role.yaml
+++ b/charts/litmus/templates/namespaced-role.yaml
@@ -10,7 +10,7 @@ metadata:
     chart: {{ include "litmus.chart" . }}
     litmuschaos.io/version: {{ .Chart.AppVersion }}
 rules:
-- apiGroups: ["","apps","batch","extensions","litmuschaos.io"]
-  resources: ["pods","pods/exec","pods/log","pods/eviction","jobs","deployments","replicasets","daemonsets","statefulsets","events","configmaps","services","chaosengines","chaosexperiments","chaosresults"]
+- apiGroups: ["","apps","batch","extensions","litmuschaos.io","apps.openshift.io"]
+  resources: ["pods","pods/exec","pods/log","pods/eviction","jobs","deployments","replicasets","replicationcontrollers","deploymentconfigs","daemonsets","statefulsets","events","configmaps","services","chaosengines","chaosexperiments","chaosresults"]
   verbs: ["get","create","update","patch","delete","list","watch","deletecollection"]
 {{ end }}

--- a/charts/litmus/templates/namespaced-role.yaml
+++ b/charts/litmus/templates/namespaced-role.yaml
@@ -11,6 +11,6 @@ metadata:
     litmuschaos.io/version: {{ .Chart.AppVersion }}
 rules:
 - apiGroups: ["","apps","batch","extensions","litmuschaos.io"]
-  resources: ["pods","pods/exec","pods/log","pods/eviction","jobs","deployments","daemonsets","statefulsets","events","configmaps","services","chaosengines","chaosexperiments","chaosresults"]
+  resources: ["pods","pods/exec","pods/log","pods/eviction","jobs","deployments","replicasets","daemonsets","statefulsets","events","configmaps","services","chaosengines","chaosexperiments","chaosresults"]
   verbs: ["get","create","update","patch","delete","list","watch","deletecollection"]
 {{ end }}


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@mayadata.io>

<!--

* https://github.com/helm/helm/tree/master/docs/chart_best_practices

Following best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

- Fixes an error in operator metrics initialization caused due to lack of permissions on replicasets
- Adds openshift resources to the role/clusterrole of operator making it consistent with the [standard manifests](https://github.com/litmuschaos/litmus/blob/master/docs/litmus-operator-v1.6.2.yaml#L22)

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #40 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] DCO signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
