### PR TITLE
remote prefix from ChaosExperiments

### DIFF
--- a/charts/kubernetes-chaos/Chart.yaml
+++ b/charts/kubernetes-chaos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.7.0"
 description: A Helm chart to install litmus chaos experiments for kubernetes category (chaos-chart)
 name: kubernetes-chaos
-version: 1.8.0
+version: 2.0.0
 home: https://litmuschaos.io
 sources:
   - https://github.com/litmuschaos/litmus

--- a/charts/kubernetes-chaos/templates/container-kill.yaml
+++ b/charts/kubernetes-chaos/templates/container-kill.yaml
@@ -5,7 +5,7 @@ description:
   message: "Kills a container belonging to an application pod \n"
 kind: ChaosExperiment
 metadata:
-  name: {{ include "kubernetes-chaos.name" . }}-container-kill
+  name: container-kill
   labels:
     instance: {{ .Release.Name }}
     chart: {{ include "kubernetes-chaos.chart" . }}

--- a/charts/kubernetes-chaos/templates/disk-fill.yaml
+++ b/charts/kubernetes-chaos/templates/disk-fill.yaml
@@ -6,7 +6,7 @@ description:
     Fillup Ephemeral Storage of a Resource
 kind: ChaosExperiment
 metadata:
-  name: {{ include "kubernetes-chaos.name" . }}-disk-fill
+  name: disk-fill
   labels:
     instance: {{ .Release.Name }}
     chart: {{ include "kubernetes-chaos.chart" . }}

--- a/charts/kubernetes-chaos/templates/disk-loss.yaml
+++ b/charts/kubernetes-chaos/templates/disk-loss.yaml
@@ -6,7 +6,7 @@ description:
     Detaching a persistent disk from a node/instance. Supports only for AWS and GCP
 kind: ChaosExperiment
 metadata:
-  name: {{ include "kubernetes-chaos.name" . }}-disk-loss
+  name: disk-loss
   labels:
     instance: {{ .Release.Name }}
     chart: {{ include "kubernetes-chaos.chart" . }}

--- a/charts/kubernetes-chaos/templates/docker-service-kill.yaml
+++ b/charts/kubernetes-chaos/templates/docker-service-kill.yaml
@@ -6,7 +6,7 @@ description:
     Kills the docker service on the application node to check the resiliency.
 kind: ChaosExperiment
 metadata:
-  name: {{ include "kubernetes-chaos.name" . }}-docker-service-kill
+  name: docker-service-kill
   labels:
     instance: {{ .Release.Name }}
     chart: {{ include "kubernetes-chaos.chart" . }}

--- a/charts/kubernetes-chaos/templates/kubelet-service-kill.yaml
+++ b/charts/kubernetes-chaos/templates/kubelet-service-kill.yaml
@@ -6,7 +6,7 @@ description:
     Kills the kubelet service on the application node to check the resiliency.
 kind: ChaosExperiment
 metadata:
-  name: {{ include "kubernetes-chaos.name" . }}-kubelet-service-kill
+  name: kubelet-service-kill
   labels:
     instance: {{ .Release.Name }}
     chart: {{ include "kubernetes-chaos.chart" . }}

--- a/charts/kubernetes-chaos/templates/node-cpu-hog.yaml
+++ b/charts/kubernetes-chaos/templates/node-cpu-hog.yaml
@@ -6,7 +6,7 @@ description:
     Give a cpu spike on a node belonging to a deployment
 kind: ChaosExperiment
 metadata:
-  name: {{ include "kubernetes-chaos.name" . }}-node-cpu-hog
+  name: node-cpu-hog
   labels:
     instance: {{ .Release.Name }}
     chart: {{ include "kubernetes-chaos.chart" . }}

--- a/charts/kubernetes-chaos/templates/node-drain.yaml
+++ b/charts/kubernetes-chaos/templates/node-drain.yaml
@@ -6,7 +6,7 @@ description:
     Drain the node where application pod is scheduled
 kind: ChaosExperiment
 metadata:
-  name: {{ include "kubernetes-chaos.name" . }}-node-drain
+  name: node-drain
   labels:
     instance: {{ .Release.Name }}
     chart: {{ include "kubernetes-chaos.chart" . }}

--- a/charts/kubernetes-chaos/templates/node-memory-hog.yaml
+++ b/charts/kubernetes-chaos/templates/node-memory-hog.yaml
@@ -6,7 +6,7 @@ description:
     Give a memory hog on a node belonging to a deployment
 kind: ChaosExperiment
 metadata:
-  name: {{ include "kubernetes-chaos.name" . }}-node-memory-hog
+  name: node-memory-hog
   labels:
     instance: {{ .Release.Name }}
     chart: {{ include "kubernetes-chaos.chart" . }}

--- a/charts/kubernetes-chaos/templates/node-taint.yaml
+++ b/charts/kubernetes-chaos/templates/node-taint.yaml
@@ -6,7 +6,7 @@ description:
     Taint the node where application pod is scheduled
 kind: ChaosExperiment
 metadata:
-  name: {{ include "kubernetes-chaos.name" . }}-node-taint
+  name: node-taint
   labels:
     instance: {{ .Release.Name }}
     chart: {{ include "kubernetes-chaos.chart" . }}

--- a/charts/kubernetes-chaos/templates/pod-cpu-hog.yaml
+++ b/charts/kubernetes-chaos/templates/pod-cpu-hog.yaml
@@ -6,7 +6,7 @@ description:
     Injects cpu consumption on pods belonging to an app deployment
 kind: ChaosExperiment
 metadata:
-  name: {{ include "kubernetes-chaos.name" . }}-pod-cpu-hog
+  name: pod-cpu-hog
   labels:
     instance: {{ .Release.Name }}
     chart: {{ include "kubernetes-chaos.chart" . }}

--- a/charts/kubernetes-chaos/templates/pod-delete.yaml
+++ b/charts/kubernetes-chaos/templates/pod-delete.yaml
@@ -6,7 +6,7 @@ description:
     Deletes a pod belonging to a deployment/statefulset/daemonset
 kind: ChaosExperiment
 metadata:
-  name: {{ include "kubernetes-chaos.name" . }}-pod-delete
+  name: pod-delete
   labels:
     instance: {{ .Release.Name }}
     chart: {{ include "kubernetes-chaos.chart" . }}

--- a/charts/kubernetes-chaos/templates/pod-memory-hog.yaml
+++ b/charts/kubernetes-chaos/templates/pod-memory-hog.yaml
@@ -6,7 +6,7 @@ description:
     Injects memory consumption on pods belonging to an app deployment
 kind: ChaosExperiment
 metadata:
-  name: {{ include "kubernetes-chaos.name" . }}-pod-memory-hog
+  name: pod-memory-hog
   labels:
     instance: {{ .Release.Name }}
     chart: {{ include "kubernetes-chaos.chart" . }}

--- a/charts/kubernetes-chaos/templates/pod-network-corruption.yaml
+++ b/charts/kubernetes-chaos/templates/pod-network-corruption.yaml
@@ -6,7 +6,7 @@ description:
     Inject network packet corruption into application pod
 kind: ChaosExperiment
 metadata:
-  name: {{ include "kubernetes-chaos.name" . }}-pod-network-corruption
+  name: pod-network-corruption
   labels:
     instance: {{ .Release.Name }}
     chart: {{ include "kubernetes-chaos.chart" . }}

--- a/charts/kubernetes-chaos/templates/pod-network-duplication.yaml
+++ b/charts/kubernetes-chaos/templates/pod-network-duplication.yaml
@@ -6,7 +6,7 @@ description:
     Injects network packet duplication on pods belonging to an app deployment
 kind: ChaosExperiment
 metadata:
-  name: {{ include "kubernetes-chaos.name" . }}-pod-network-duplication
+  name: pod-network-duplication
   labels:
     instance: {{ .Release.Name }}
     chart: {{ include "kubernetes-chaos.chart" . }}

--- a/charts/kubernetes-chaos/templates/pod-network-latency.yaml
+++ b/charts/kubernetes-chaos/templates/pod-network-latency.yaml
@@ -6,7 +6,7 @@ description:
     Injects network latency on pods belonging to an app deployment
 kind: ChaosExperiment
 metadata:
-  name: {{ include "kubernetes-chaos.name" . }}-pod-network-latency
+  name: pod-network-latency
   labels:
     instance: {{ .Release.Name }}
     chart: {{ include "kubernetes-chaos.chart" . }}

--- a/charts/kubernetes-chaos/templates/pod-network-loss.yaml
+++ b/charts/kubernetes-chaos/templates/pod-network-loss.yaml
@@ -6,7 +6,7 @@ description:
     Injects network packet loss on pods belonging to an app deployment
 kind: ChaosExperiment
 metadata:
-  name: {{ include "kubernetes-chaos.name" . }}-pod-network-loss
+  name: pod-network-loss
   labels:
     instance: {{ .Release.Name }}
     chart: {{ include "kubernetes-chaos.chart" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Not sure if this was a bug but it solved it for me:

The `ChaosResults` name is always different to what the Chaos Runner expects:

ChaosEngine name: `api-gateway-1-200904`
ChaosExperiment name: `k8s-pod-network-loss` <--- from helm chart
ChaosResult name: `api-gateway-1-200904-pod-network-loss` <--- auto created? missing the k8s prefix

Chaos Runner error:
```
I0904 04:01:03.070760       1 runner.go:76] Unable to Update ChaosEngine Status due to: Unable to get ChaosResult Name: api-gateway-1-200904-k8s-pod-network-loss in namespace: litmus, due to error: chaosresults.litmuschaos.io "api-gateway-1-200904-k8s-pod-network-loss" not found: chaosresults.litmuschaos.io "api-gateway-1-200904-k8s-pod-network-loss" not found
```

I've tried updating the `Spec.Definitions.Labels.Name` field from `pod-network-loss` to `k8s-pod-network-loss` but that didn't solve it either and log still included the missing `k8s` prefix.

The `pod-autoscaler` does not have the prefix to begin with.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] DCO signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
