### PR TITLE
[litmus-portal] Option to override Mongo pvc & frontend-service NodePort values

### DIFF
--- a/charts/litmus-portal/Chart.yaml
+++ b/charts/litmus-portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.12.0"
 description: A Helm chart to install litmus portal
 name: litmus-portal
-version: 1.12.2
+version: 1.12.1
 home: https://litmuschaos.io
 sources:
   - https://github.com/litmuschaos/litmus

--- a/charts/litmus-portal/Chart.yaml
+++ b/charts/litmus-portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.12.0"
 description: A Helm chart to install litmus portal
 name: litmus-portal
-version: 1.12.1
+version: 1.12.2
 home: https://litmuschaos.io
 sources:
   - https://github.com/litmuschaos/litmus

--- a/charts/litmus-portal/Chart.yaml
+++ b/charts/litmus-portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.12.0"
 description: A Helm chart to install litmus portal
 name: litmus-portal
-version: 1.12.0
+version: 1.12.1
 home: https://litmuschaos.io
 sources:
   - https://github.com/litmuschaos/litmus

--- a/charts/litmus-portal/templates/mongo-pvc.yaml
+++ b/charts/litmus-portal/templates/mongo-pvc.yaml
@@ -1,13 +1,17 @@
+{{- $values := .Values.mongoDB.deployment.persistence -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: mongo-pv-claim
-  namespace:  {{ .Values.portalNamespace }}
+  namespace: {{ .Values.portalNamespace }}
   labels:
     app: mongo
 spec:
   accessModes:
-    - ReadWriteOnce
+    - {{ $values.accessMode }}
   resources:
     requests:
-      storage: 20Gi
+      storage: {{ $values.size }}
+  {{- if $values.storageClass }}
+  storageClassName: {{ $values.storageClass }}
+  {{- end }}

--- a/charts/litmus-portal/templates/portal-frontend-svc.yaml
+++ b/charts/litmus-portal/templates/portal-frontend-svc.yaml
@@ -9,5 +9,8 @@ spec:
     - name: http
       port: {{ .Values.portalFrontend.service.port }}
       targetPort: {{ .Values.portalFrontend.service.targetPort }}
+      {{- if .Values.portalFrontend.service.nodePort }}
+      nodePort: {{ .Values.portalFrontend.service.nodePort }}
+      {{- end }}
   selector:
     component: litmusportal-frontend

--- a/charts/litmus-portal/templates/portal-frontend-svc.yaml
+++ b/charts/litmus-portal/templates/portal-frontend-svc.yaml
@@ -9,8 +9,5 @@ spec:
     - name: http
       port: {{ .Values.portalFrontend.service.port }}
       targetPort: {{ .Values.portalFrontend.service.targetPort }}
-      {{- if .Values.portalFrontend.service.nodePort }}
-      nodePort: {{ .Values.portalFrontend.service.nodePort }}
-      {{- end }}
   selector:
     component: litmusportal-frontend

--- a/charts/litmus-portal/values.yaml
+++ b/charts/litmus-portal/values.yaml
@@ -31,7 +31,6 @@ portalFrontend:
   service:
     port: 9091
     targetPort: 8080
-    # nodePort:
 
 portalServer:
   deployment:

--- a/charts/litmus-portal/values.yaml
+++ b/charts/litmus-portal/values.yaml
@@ -31,6 +31,7 @@ portalFrontend:
   service:
     port: 9091
     targetPort: 8080
+    # nodePort:
 
 portalServer:
   deployment:

--- a/charts/litmus-portal/values.yaml
+++ b/charts/litmus-portal/values.yaml
@@ -91,6 +91,10 @@ mongoDB:
     imagePullPolicy: "Always"
     port: 27017
     resources: {}
+    persistence:
+      size: 20Gi
+      accessMode: ReadWriteOnce
+      #storageClass: ""
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following


### PR DESCRIPTION
- Make the pvc size, storageClass, and accessMode properties for Mongo configurable
- Allow specification of frontend-service NodePort 


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] DCO signed
- [X] Chart Version bumped
