### PR TITLE
Fix incompatibility when install to GKE

### DIFF
--- a/charts/litmus-2-0-0-beta/Chart.yaml
+++ b/charts/litmus-2-0-0-beta/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 appVersion: "2.0.0"
 description: A Helm chart to install litmus portal
 name: litmus-2-0-0-beta
-version: 2.0.5-Beta1
-kubeVersion: ">=1.16"
+version: 2.0.6-Beta1
+kubeVersion: ">=1.16.0-0"
 home: https://litmuschaos.io
 sources:
   - https://github.com/litmuschaos/litmus

--- a/charts/litmus-2-0-0-beta/README.md
+++ b/charts/litmus-2-0-0-beta/README.md
@@ -1,6 +1,6 @@
 # litmus-2-0-0-beta
 
-![Version: 2.0.5-Beta1](https://img.shields.io/badge/Version-2.0.5--Beta1-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 2.0.6-Beta1](https://img.shields.io/badge/Version-2.0.6--Beta1-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart to install litmus portal
 
@@ -20,7 +20,7 @@ A Helm chart to install litmus portal
 
 ## Requirements
 
-Kubernetes: `>=1.16`
+Kubernetes: `>=1.16.0-0`
 
 ## Installing the Chart
 


### PR DESCRIPTION
Signed-off-by: Jasstkn <jasssstkn@yahoo.com>

<!--

* https://github.com/helm/helm/tree/master/docs/chart_best_practices

Following best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Fixes error:
```
Error: Failed to render chart: exit status 1: Error: chart requires kubeVersion: >=1.16 which is incompatible with Kubernetes v1.19.8-gke.1600
```

#### Special notes for your reviewer:

This issue is possibly reproducing in the other Clouds which have following Kubernetes version format: 1.20.2-xx
Example of fix: https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/Chart.yaml#L23

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] DCO signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
