### PR TITLE
Adding HUB_BRANCH_NAME env. for server

### DIFF
--- a/charts/litmus-2-0-0-beta/Chart.yaml
+++ b/charts/litmus-2-0-0-beta/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.0.0"
 description: A Helm chart to install litmus portal
 name: litmus-2-0-0-beta
-version: 2.0.9-Beta3
+version: 2.0.10-Beta3
 kubeVersion: ">=1.16.0-0"
 home: https://litmuschaos.io
 sources:

--- a/charts/litmus-2-0-0-beta/Chart.yaml
+++ b/charts/litmus-2-0-0-beta/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.0.0"
 description: A Helm chart to install litmus portal
 name: litmus-2-0-0-beta
-version: 2.0.10-Beta3
+version: 2.0.11-Beta3
 kubeVersion: ">=1.16.0-0"
 home: https://litmuschaos.io
 sources:

--- a/charts/litmus-2-0-0-beta/README.md
+++ b/charts/litmus-2-0-0-beta/README.md
@@ -1,6 +1,6 @@
 # litmus-2-0-0-beta
 
-![Version: 2.0.10-Beta3](https://img.shields.io/badge/Version-2.0.10--Beta3-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 2.0.11-Beta3](https://img.shields.io/badge/Version-2.0.11--Beta3-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart to install litmus portal
 

--- a/charts/litmus-2-0-0-beta/README.md
+++ b/charts/litmus-2-0-0-beta/README.md
@@ -8,15 +8,15 @@ A Helm chart to install litmus portal
 
 ## Maintainers
 
-| Name | Email | Url |
-| ---- | ------ | --- |
-| rajdas98 | raj.das@mayadata.io |  |
-| ispeakc0de | shubham.chaudhary@mayadata.io |  |
-| jasstkn | jasssstkn@yahoo.com |  |
+| Name       | Email                         | Url |
+| ---------- | ----------------------------- | --- |
+| rajdas98   | raj.das@mayadata.io           |     |
+| ispeakc0de | shubham.chaudhary@mayadata.io |     |
+| jasstkn    | jasssstkn@yahoo.com           |     |
 
 ## Source Code
 
-* <https://github.com/litmuschaos/litmus>
+- <https://github.com/litmuschaos/litmus>
 
 ## Requirements
 
@@ -31,73 +31,76 @@ $ helm repo add litmuschaos https://litmuschaos.github.io/litmus-helm/
 $ helm install litmus-portal litmuschaos/litmus-2-0-0-beta
 ```
 
-***Note***: This chart is in its beta release. To find it using `helm search` add `--devel` option.
+**_Note_**: This chart is in its beta release. To find it using `helm search` add `--devel` option.
 
 ## Values
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| adminConfig.DBPASSWORD | string | `"1234"` |  |
-| adminConfig.DBUSER | string | `"admin"` |  |
-| adminConfig.DB_PORT | string | `"27017"` |  |
-| adminConfig.DB_SERVER | string | `""` | leave empty if uses Mongo DB deployed by this chart |
-| adminConfig.JWTSecret | string | `"litmus-portal@123"` |  |
-| imagePullSecrets | list | `[]` |  |
-| ingress.annotations | object | `{}` |  |
-| ingress.enabled | bool | `false` |  |
-| ingress.host | string | `""` |  |
-| ingress.name | string | `"litmus-ingress"` |  |
-| ingress.tls | list | `[]` |  |
-| mongo.containerPort | int | `27017` |  |
-| mongo.image.pullPolicy | string | `"Always"` |  |
-| mongo.image.repository | string | `"mongo"` |  |
-| mongo.image.tag | string | `"4.2.8"` |  |
-| mongo.persistence.accessMode | string | `"ReadWriteOnce"` |  |
-| mongo.persistence.size | string | `"20Gi"` |  |
-| mongo.replicas | int | `1` |  |
-| mongo.resources | object | `{}` |  |
-| mongo.service.port | int | `27017` |  |
-| mongo.service.targetPort | int | `27017` |  |
-| mongo.service.type | string | `"ClusterIP"` |  |
-| portal.frontend.containerPort | int | `8080` |  |
-| portal.frontend.image.pullPolicy | string | `"Always"` |  |
-| portal.frontend.image.repository | string | `"litmuschaos/litmusportal-frontend"` |  |
-| portal.frontend.image.tag | string | `"2.0.0-Beta3"` |  |
-| portal.frontend.replicas | int | `1` |  |
-| portal.frontend.resources | object | `{}` |  |
-| portal.frontend.service.port | int | `9091` |  |
-| portal.frontend.service.targetPort | int | `8080` |  |
-| portal.frontend.service.type | string | `"NodePort"` |  |
-| portal.server.authServer.containerPort | int | `3000` |  |
-| portal.server.authServer.env.ADMIN_PASSWORD | string | `"litmus"` |  |
-| portal.server.authServer.env.ADMIN_USERNAME | string | `"admin"` |  |
-| portal.server.authServer.image.pullPolicy | string | `"Always"` |  |
-| portal.server.authServer.image.repository | string | `"litmuschaos/litmusportal-auth-server"` |  |
-| portal.server.authServer.image.tag | string | `"2.0.0-Beta3"` |  |
-| portal.server.authServer.resources | object | `{}` |  |
-| portal.server.graphqlServer.containerPort | int | `8080` |  |
-| portal.server.graphqlServer.env.ARGO_SERVER_IMAGE | string | `"argoproj/argocli:v2.9.3"` |  |
-| portal.server.graphqlServer.env.ARGO_WORKFLOW_CONTROLLER_IMAGE | string | `"argoproj/workflow-controller:v2.9.3"` |  |
-| portal.server.graphqlServer.env.ARGO_WORKFLOW_EXECUTOR_IMAGE | string | `"argoproj/argoexec:v2.9.3"` |  |
-| portal.server.graphqlServer.env.EVENT_TRACKER_IMAGE | string | `"litmuschaos/litmusportal-event-tracker:2.0.0-Beta3"` |  |
-| portal.server.graphqlServer.env.LITMUS_CHAOS_EXPORTER_IMAGE | string | `"litmuschaos/chaos-exporter:1.13.3"` |  |
-| portal.server.graphqlServer.env.LITMUS_CHAOS_OPERATOR_IMAGE | string | `"litmuschaos/chaos-operator:1.13.3"` |  |
-| portal.server.graphqlServer.env.LITMUS_CHAOS_RUNNER_IMAGE | string | `"litmuschaos/chaos-runner:1.13.3"` |  |
-| portal.server.graphqlServer.env.SELF_CLUSTER | string | `"true"` |  |
-| portal.server.graphqlServer.env.SERVER_SERVICE_NAME | string | `"litmusportal-server-service"` |  |
-| portal.server.graphqlServer.env.SUBSCRIBER_IMAGE | string | `"litmuschaos/litmusportal-subscriber:2.0.0-Beta3"` |  |
-| portal.server.graphqlServer.image.pullPolicy | string | `"Always"` |  |
-| portal.server.graphqlServer.image.repository | string | `"litmuschaos/litmusportal-server"` |  |
-| portal.server.graphqlServer.image.tag | string | `"2.0.0-Beta3"` |  |
-| portal.server.graphqlServer.resources | object | `{}` |  |
-| portal.server.replicas | int | `1` |  |
-| portal.server.service.authServer.port | int | `9003` |  |
-| portal.server.service.authServer.targetPort | int | `3000` |  |
-| portal.server.service.graphqlServer.port | int | `9002` |  |
-| portal.server.service.graphqlServer.targetPort | int | `8080` |  |
-| portal.server.service.type | string | `"NodePort"` |  |
-| portal.server.serviceAccountName | string | `"litmus-server-account"` |  |
-| portalScope | string | `"cluster"` |  |
+| Key                                                            | Type   | Default                                                | Description                                         |
+| -------------------------------------------------------------- | ------ | ------------------------------------------------------ | --------------------------------------------------- |
+| adminConfig.DBPASSWORD                                         | string | `"1234"`                                               |                                                     |
+| adminConfig.DBUSER                                             | string | `"admin"`                                              |                                                     |
+| adminConfig.DB_PORT                                            | string | `"27017"`                                              |                                                     |
+| adminConfig.DB_SERVER                                          | string | `""`                                                   | leave empty if uses Mongo DB deployed by this chart |
+| adminConfig.JWTSecret                                          | string | `"litmus-portal@123"`                                  |                                                     |
+| imagePullSecrets                                               | list   | `[]`                                                   |                                                     |
+| ingress.annotations                                            | object | `{}`                                                   |                                                     |
+| ingress.enabled                                                | bool   | `false`                                                |                                                     |
+| ingress.host                                                   | string | `""`                                                   |                                                     |
+| ingress.name                                                   | string | `"litmus-ingress"`                                     |                                                     |
+| ingress.tls                                                    | list   | `[]`                                                   |                                                     |
+| mongo.containerPort                                            | int    | `27017`                                                |                                                     |
+| mongo.image.pullPolicy                                         | string | `"Always"`                                             |                                                     |
+| mongo.image.repository                                         | string | `"mongo"`                                              |                                                     |
+| mongo.image.tag                                                | string | `"4.2.8"`                                              |                                                     |
+| mongo.persistence.accessMode                                   | string | `"ReadWriteOnce"`                                      |                                                     |
+| mongo.persistence.size                                         | string | `"20Gi"`                                               |                                                     |
+| mongo.replicas                                                 | int    | `1`                                                    |                                                     |
+| mongo.resources                                                | object | `{}`                                                   |                                                     |
+| mongo.service.port                                             | int    | `27017`                                                |                                                     |
+| mongo.service.targetPort                                       | int    | `27017`                                                |                                                     |
+| mongo.service.type                                             | string | `"ClusterIP"`                                          |                                                     |
+| portal.frontend.containerPort                                  | int    | `8080`                                                 |                                                     |
+| portal.frontend.image.pullPolicy                               | string | `"Always"`                                             |                                                     |
+| portal.frontend.image.repository                               | string | `"litmuschaos/litmusportal-frontend"`                  |                                                     |
+| portal.frontend.image.tag                                      | string | `"2.0.0-Beta3"`                                        |                                                     |
+| portal.frontend.replicas                                       | int    | `1`                                                    |                                                     |
+| portal.frontend.resources                                      | object | `{}`                                                   |                                                     |
+| portal.frontend.service.port                                   | int    | `9091`                                                 |                                                     |
+| portal.frontend.service.targetPort                             | int    | `8080`                                                 |                                                     |
+| portal.frontend.service.type                                   | string | `"NodePort"`                                           |                                                     |
+| portal.server.authServer.containerPort                         | int    | `3000`                                                 |                                                     |
+| portal.server.authServer.env.ADMIN_PASSWORD                    | string | `"litmus"`                                             |                                                     |
+| portal.server.authServer.env.ADMIN_USERNAME                    | string | `"admin"`                                              |                                                     |
+| portal.server.authServer.image.pullPolicy                      | string | `"Always"`                                             |                                                     |
+| portal.server.authServer.image.repository                      | string | `"litmuschaos/litmusportal-auth-server"`               |                                                     |
+| portal.server.authServer.image.tag                             | string | `"2.0.0-Beta3"`                                        |                                                     |
+| portal.server.authServer.resources                             | object | `{}`                                                   |                                                     |
+| portal.server.graphqlServer.containerPort                      | int    | `8080`                                                 |                                                     |
+| portal.server.graphqlServer.env.ARGO_SERVER_IMAGE              | string | `"argoproj/argocli:v2.9.3"`                            |                                                     |
+| portal.server.graphqlServer.env.ARGO_WORKFLOW_CONTROLLER_IMAGE | string | `"argoproj/workflow-controller:v2.9.3"`                |                                                     |
+| portal.server.graphqlServer.env.ARGO_WORKFLOW_EXECUTOR_IMAGE   | string | `"argoproj/argoexec:v2.9.3"`                           |                                                     |
+| portal.server.graphqlServer.env.EVENT_TRACKER_IMAGE            | string | `"litmuschaos/litmusportal-event-tracker:2.0.0-Beta3"` |                                                     |
+| portal.server.graphqlServer.env.LITMUS_CHAOS_EXPORTER_IMAGE    | string | `"litmuschaos/chaos-exporter:1.13.3"`                  |                                                     |
+| portal.server.graphqlServer.env.LITMUS_CHAOS_OPERATOR_IMAGE    | string | `"litmuschaos/chaos-operator:1.13.3"`                  |                                                     |
+| portal.server.graphqlServer.env.LITMUS_CHAOS_RUNNER_IMAGE      | string | `"litmuschaos/chaos-runner:1.13.3"`                    |                                                     |
+| portal.server.graphqlServer.env.SELF_CLUSTER                   | string | `"true"`                                               |                                                     |
+| portal.server.graphqlServer.env.SERVER_SERVICE_NAME            | string | `"litmusportal-server-service"`                        |                                                     |
+| portal.server.graphqlServer.env.PORTAL_ENDPOINT                | string | `"http://litmusportal-server-service:9002"`            |                                                     |
+| portal.server.graphqlServer.env.SUBSCRIBER_IMAGE               | string | `"litmuschaos/litmusportal-subscriber:2.0.0-Beta3"`    |                                                     |
+| portal.server.graphqlServer.env.CONTAINER_RUNTIME_EXECUTOR     | string | `"k8sapi"`                                             |                                                     |
+| portal.server.graphqlServer.image.pullPolicy                   | string | `"Always"`                                             |                                                     |
+| portal.server.graphqlServer.image.repository                   | string | `"litmuschaos/litmusportal-server"`                    |                                                     |
+| portal.server.graphqlServer.image.tag                          | string | `"2.0.0-Beta3"`                                        |                                                     |
+| portal.server.graphqlServer.resources                          | object | `{}`                                                   |                                                     |
+| portal.server.replicas                                         | int    | `1`                                                    |                                                     |
+| portal.server.service.authServer.port                          | int    | `9003`                                                 |                                                     |
+| portal.server.service.authServer.targetPort                    | int    | `3000`                                                 |                                                     |
+| portal.server.service.graphqlServer.port                       | int    | `9002`                                                 |                                                     |
+| portal.server.service.graphqlServer.targetPort                 | int    | `8080`                                                 |                                                     |
+| portal.server.service.type                                     | string | `"NodePort"`                                           |                                                     |
+| portal.server.serviceAccountName                               | string | `"litmus-server-account"`                              |                                                     |
+| portalScope                                                    | string | `"cluster"`                                            |                                                     |
 
-----------------------------------------------
+---
+
 Autogenerated from chart metadata using [helm-docs v1.5.0](https://github.com/norwoodj/helm-docs/releases/v1.5.0)

--- a/charts/litmus-2-0-0-beta/README.md
+++ b/charts/litmus-2-0-0-beta/README.md
@@ -8,15 +8,15 @@ A Helm chart to install litmus portal
 
 ## Maintainers
 
-| Name | Email | Url |
-| ---- | ------ | --- |
-| rajdas98 | raj.das@mayadata.io |  |
-| ispeakc0de | shubham.chaudhary@mayadata.io |  |
-| jasstkn | jasssstkn@yahoo.com |  |
+| Name       | Email                         | Url |
+| ---------- | ----------------------------- | --- |
+| rajdas98   | raj.das@mayadata.io           |     |
+| ispeakc0de | shubham.chaudhary@mayadata.io |     |
+| jasstkn    | jasssstkn@yahoo.com           |     |
 
 ## Source Code
 
-* <https://github.com/litmuschaos/litmus>
+- <https://github.com/litmuschaos/litmus>
 
 ## Requirements
 
@@ -31,75 +31,77 @@ $ helm repo add litmuschaos https://litmuschaos.github.io/litmus-helm/
 $ helm install litmus-portal litmuschaos/litmus-2-0-0-beta
 ```
 
-***Note***: This chart is in its beta release. To find it using `helm search` add `--devel` option.
+**_Note_**: This chart is in its beta release. To find it using `helm search` add `--devel` option.
 
 ## Values
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| adminConfig.DBPASSWORD | string | `"1234"` |  |
-| adminConfig.DBUSER | string | `"admin"` |  |
-| adminConfig.DB_PORT | string | `"27017"` |  |
-| adminConfig.DB_SERVER | string | `""` | leave empty if uses Mongo DB deployed by this chart |
-| adminConfig.JWTSecret | string | `"litmus-portal@123"` |  |
-| imagePullSecrets | list | `[]` |  |
-| ingress.annotations | object | `{}` |  |
-| ingress.enabled | bool | `false` |  |
-| ingress.host | string | `""` |  |
-| ingress.name | string | `"litmus-ingress"` |  |
-| ingress.tls | list | `[]` |  |
-| mongo.containerPort | int | `27017` |  |
-| mongo.image.pullPolicy | string | `"Always"` |  |
-| mongo.image.repository | string | `"mongo"` |  |
-| mongo.image.tag | string | `"4.2.8"` |  |
-| mongo.persistence.accessMode | string | `"ReadWriteOnce"` |  |
-| mongo.persistence.size | string | `"20Gi"` |  |
-| mongo.replicas | int | `1` |  |
-| mongo.resources | object | `{}` |  |
-| mongo.service.port | int | `27017` |  |
-| mongo.service.targetPort | int | `27017` |  |
-| mongo.service.type | string | `"ClusterIP"` |  |
-| portal.frontend.containerPort | int | `8080` |  |
-| portal.frontend.image.pullPolicy | string | `"Always"` |  |
-| portal.frontend.image.repository | string | `"litmuschaos/litmusportal-frontend"` |  |
-| portal.frontend.image.tag | string | `"2.0.0-Beta3"` |  |
-| portal.frontend.replicas | int | `1` |  |
-| portal.frontend.resources | object | `{}` |  |
-| portal.frontend.service.port | int | `9091` |  |
-| portal.frontend.service.targetPort | int | `8080` |  |
-| portal.frontend.service.type | string | `"NodePort"` |  |
-| portal.server.authServer.containerPort | int | `3000` |  |
-| portal.server.authServer.env.ADMIN_PASSWORD | string | `"litmus"` |  |
-| portal.server.authServer.env.ADMIN_USERNAME | string | `"admin"` |  |
-| portal.server.authServer.image.pullPolicy | string | `"Always"` |  |
-| portal.server.authServer.image.repository | string | `"litmuschaos/litmusportal-auth-server"` |  |
-| portal.server.authServer.image.tag | string | `"2.0.0-Beta3"` |  |
-| portal.server.authServer.resources | object | `{}` |  |
-| portal.server.graphqlServer.containerPort | int | `8080` |  |
-| portal.server.graphqlServer.env.ARGO_SERVER_IMAGE | string | `"argoproj/argocli:v2.9.3"` |  |
-| portal.server.graphqlServer.env.ARGO_WORKFLOW_CONTROLLER_IMAGE | string | `"argoproj/workflow-controller:v2.9.3"` |  |
-| portal.server.graphqlServer.env.ARGO_WORKFLOW_EXECUTOR_IMAGE | string | `"argoproj/argoexec:v2.9.3"` |  |
-| portal.server.graphqlServer.env.CONTAINER_RUNTIME_EXECUTOR | string | `"k8sapi"` |  |
-| portal.server.graphqlServer.env.EVENT_TRACKER_IMAGE | string | `"litmuschaos/litmusportal-event-tracker:2.0.0-Beta3"` |  |
-| portal.server.graphqlServer.env.LITMUS_CHAOS_EXPORTER_IMAGE | string | `"litmuschaos/chaos-exporter:1.13.3"` |  |
-| portal.server.graphqlServer.env.LITMUS_CHAOS_OPERATOR_IMAGE | string | `"litmuschaos/chaos-operator:1.13.3"` |  |
-| portal.server.graphqlServer.env.LITMUS_CHAOS_RUNNER_IMAGE | string | `"litmuschaos/chaos-runner:1.13.3"` |  |
-| portal.server.graphqlServer.env.PORTAL_ENDPOINT | string | `"http://litmusportal-server-service:9002"` |  |
-| portal.server.graphqlServer.env.SELF_CLUSTER | string | `"true"` |  |
-| portal.server.graphqlServer.env.SERVER_SERVICE_NAME | string | `"litmusportal-server-service"` |  |
-| portal.server.graphqlServer.env.SUBSCRIBER_IMAGE | string | `"litmuschaos/litmusportal-subscriber:2.0.0-Beta3"` |  |
-| portal.server.graphqlServer.image.pullPolicy | string | `"Always"` |  |
-| portal.server.graphqlServer.image.repository | string | `"litmuschaos/litmusportal-server"` |  |
-| portal.server.graphqlServer.image.tag | string | `"2.0.0-Beta3"` |  |
-| portal.server.graphqlServer.resources | object | `{}` |  |
-| portal.server.replicas | int | `1` |  |
-| portal.server.service.authServer.port | int | `9003` |  |
-| portal.server.service.authServer.targetPort | int | `3000` |  |
-| portal.server.service.graphqlServer.port | int | `9002` |  |
-| portal.server.service.graphqlServer.targetPort | int | `8080` |  |
-| portal.server.service.type | string | `"NodePort"` |  |
-| portal.server.serviceAccountName | string | `"litmus-server-account"` |  |
-| portalScope | string | `"cluster"` |  |
+| Key                                                            | Type   | Default                                                | Description                                         |
+| -------------------------------------------------------------- | ------ | ------------------------------------------------------ | --------------------------------------------------- |
+| adminConfig.DBPASSWORD                                         | string | `"1234"`                                               |                                                     |
+| adminConfig.DBUSER                                             | string | `"admin"`                                              |                                                     |
+| adminConfig.DB_PORT                                            | string | `"27017"`                                              |                                                     |
+| adminConfig.DB_SERVER                                          | string | `""`                                                   | leave empty if uses Mongo DB deployed by this chart |
+| adminConfig.JWTSecret                                          | string | `"litmus-portal@123"`                                  |                                                     |
+| imagePullSecrets                                               | list   | `[]`                                                   |                                                     |
+| ingress.annotations                                            | object | `{}`                                                   |                                                     |
+| ingress.enabled                                                | bool   | `false`                                                |                                                     |
+| ingress.host                                                   | string | `""`                                                   |                                                     |
+| ingress.name                                                   | string | `"litmus-ingress"`                                     |                                                     |
+| ingress.tls                                                    | list   | `[]`                                                   |                                                     |
+| mongo.containerPort                                            | int    | `27017`                                                |                                                     |
+| mongo.image.pullPolicy                                         | string | `"Always"`                                             |                                                     |
+| mongo.image.repository                                         | string | `"mongo"`                                              |                                                     |
+| mongo.image.tag                                                | string | `"4.2.8"`                                              |                                                     |
+| mongo.persistence.accessMode                                   | string | `"ReadWriteOnce"`                                      |                                                     |
+| mongo.persistence.size                                         | string | `"20Gi"`                                               |                                                     |
+| mongo.replicas                                                 | int    | `1`                                                    |                                                     |
+| mongo.resources                                                | object | `{}`                                                   |                                                     |
+| mongo.service.port                                             | int    | `27017`                                                |                                                     |
+| mongo.service.targetPort                                       | int    | `27017`                                                |                                                     |
+| mongo.service.type                                             | string | `"ClusterIP"`                                          |                                                     |
+| portal.frontend.containerPort                                  | int    | `8080`                                                 |                                                     |
+| portal.frontend.image.pullPolicy                               | string | `"Always"`                                             |                                                     |
+| portal.frontend.image.repository                               | string | `"litmuschaos/litmusportal-frontend"`                  |                                                     |
+| portal.frontend.image.tag                                      | string | `"2.0.0-Beta3"`                                        |                                                     |
+| portal.frontend.replicas                                       | int    | `1`                                                    |                                                     |
+| portal.frontend.resources                                      | object | `{}`                                                   |                                                     |
+| portal.frontend.service.port                                   | int    | `9091`                                                 |                                                     |
+| portal.frontend.service.targetPort                             | int    | `8080`                                                 |                                                     |
+| portal.frontend.service.type                                   | string | `"NodePort"`                                           |                                                     |
+| portal.server.authServer.containerPort                         | int    | `3000`                                                 |                                                     |
+| portal.server.authServer.env.ADMIN_PASSWORD                    | string | `"litmus"`                                             |                                                     |
+| portal.server.authServer.env.ADMIN_USERNAME                    | string | `"admin"`                                              |                                                     |
+| portal.server.authServer.image.pullPolicy                      | string | `"Always"`                                             |                                                     |
+| portal.server.authServer.image.repository                      | string | `"litmuschaos/litmusportal-auth-server"`               |                                                     |
+| portal.server.authServer.image.tag                             | string | `"2.0.0-Beta3"`                                        |                                                     |
+| portal.server.authServer.resources                             | object | `{}`                                                   |                                                     |
+| portal.server.graphqlServer.containerPort                      | int    | `8080`                                                 |                                                     |
+| portal.server.graphqlServer.env.ARGO_SERVER_IMAGE              | string | `"argoproj/argocli:v2.9.3"`                            |                                                     |
+| portal.server.graphqlServer.env.ARGO_WORKFLOW_CONTROLLER_IMAGE | string | `"argoproj/workflow-controller:v2.9.3"`                |                                                     |
+| portal.server.graphqlServer.env.ARGO_WORKFLOW_EXECUTOR_IMAGE   | string | `"argoproj/argoexec:v2.9.3"`                           |                                                     |
+| portal.server.graphqlServer.env.CONTAINER_RUNTIME_EXECUTOR     | string | `"k8sapi"`                                             |                                                     |
+| portal.server.graphqlServer.env.HUB_BRANCH_NAME                | string | `"v1.13.x"`                                            |                                                     |
+| portal.server.graphqlServer.env.EVENT_TRACKER_IMAGE            | string | `"litmuschaos/litmusportal-event-tracker:2.0.0-Beta3"` |                                                     |
+| portal.server.graphqlServer.env.LITMUS_CHAOS_EXPORTER_IMAGE    | string | `"litmuschaos/chaos-exporter:1.13.3"`                  |                                                     |
+| portal.server.graphqlServer.env.LITMUS_CHAOS_OPERATOR_IMAGE    | string | `"litmuschaos/chaos-operator:1.13.3"`                  |                                                     |
+| portal.server.graphqlServer.env.LITMUS_CHAOS_RUNNER_IMAGE      | string | `"litmuschaos/chaos-runner:1.13.3"`                    |                                                     |
+| portal.server.graphqlServer.env.PORTAL_ENDPOINT                | string | `"http://litmusportal-server-service:9002"`            |                                                     |
+| portal.server.graphqlServer.env.SELF_CLUSTER                   | string | `"true"`                                               |                                                     |
+| portal.server.graphqlServer.env.SERVER_SERVICE_NAME            | string | `"litmusportal-server-service"`                        |                                                     |
+| portal.server.graphqlServer.env.SUBSCRIBER_IMAGE               | string | `"litmuschaos/litmusportal-subscriber:2.0.0-Beta3"`    |                                                     |
+| portal.server.graphqlServer.image.pullPolicy                   | string | `"Always"`                                             |                                                     |
+| portal.server.graphqlServer.image.repository                   | string | `"litmuschaos/litmusportal-server"`                    |                                                     |
+| portal.server.graphqlServer.image.tag                          | string | `"2.0.0-Beta3"`                                        |                                                     |
+| portal.server.graphqlServer.resources                          | object | `{}`                                                   |                                                     |
+| portal.server.replicas                                         | int    | `1`                                                    |                                                     |
+| portal.server.service.authServer.port                          | int    | `9003`                                                 |                                                     |
+| portal.server.service.authServer.targetPort                    | int    | `3000`                                                 |                                                     |
+| portal.server.service.graphqlServer.port                       | int    | `9002`                                                 |                                                     |
+| portal.server.service.graphqlServer.targetPort                 | int    | `8080`                                                 |                                                     |
+| portal.server.service.type                                     | string | `"NodePort"`                                           |                                                     |
+| portal.server.serviceAccountName                               | string | `"litmus-server-account"`                              |                                                     |
+| portalScope                                                    | string | `"cluster"`                                            |                                                     |
 
-----------------------------------------------
+---
+
 Autogenerated from chart metadata using [helm-docs v1.5.0](https://github.com/norwoodj/helm-docs/releases/v1.5.0)

--- a/charts/litmus-2-0-0-beta/README.md
+++ b/charts/litmus-2-0-0-beta/README.md
@@ -1,6 +1,6 @@
 # litmus-2-0-0-beta
 
-![Version: 2.0.9-Beta3](https://img.shields.io/badge/Version-2.0.9--Beta3-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 2.0.10-Beta3](https://img.shields.io/badge/Version-2.0.10--Beta3-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart to install litmus portal
 

--- a/charts/litmus-2-0-0-beta/README.md
+++ b/charts/litmus-2-0-0-beta/README.md
@@ -8,15 +8,15 @@ A Helm chart to install litmus portal
 
 ## Maintainers
 
-| Name       | Email                         | Url |
-| ---------- | ----------------------------- | --- |
-| rajdas98   | raj.das@mayadata.io           |     |
-| ispeakc0de | shubham.chaudhary@mayadata.io |     |
-| jasstkn    | jasssstkn@yahoo.com           |     |
+| Name | Email | Url |
+| ---- | ------ | --- |
+| rajdas98 | raj.das@mayadata.io |  |
+| ispeakc0de | shubham.chaudhary@mayadata.io |  |
+| jasstkn | jasssstkn@yahoo.com |  |
 
 ## Source Code
 
-- <https://github.com/litmuschaos/litmus>
+* <https://github.com/litmuschaos/litmus>
 
 ## Requirements
 
@@ -31,76 +31,75 @@ $ helm repo add litmuschaos https://litmuschaos.github.io/litmus-helm/
 $ helm install litmus-portal litmuschaos/litmus-2-0-0-beta
 ```
 
-**_Note_**: This chart is in its beta release. To find it using `helm search` add `--devel` option.
+***Note***: This chart is in its beta release. To find it using `helm search` add `--devel` option.
 
 ## Values
 
-| Key                                                            | Type   | Default                                                | Description                                         |
-| -------------------------------------------------------------- | ------ | ------------------------------------------------------ | --------------------------------------------------- |
-| adminConfig.DBPASSWORD                                         | string | `"1234"`                                               |                                                     |
-| adminConfig.DBUSER                                             | string | `"admin"`                                              |                                                     |
-| adminConfig.DB_PORT                                            | string | `"27017"`                                              |                                                     |
-| adminConfig.DB_SERVER                                          | string | `""`                                                   | leave empty if uses Mongo DB deployed by this chart |
-| adminConfig.JWTSecret                                          | string | `"litmus-portal@123"`                                  |                                                     |
-| imagePullSecrets                                               | list   | `[]`                                                   |                                                     |
-| ingress.annotations                                            | object | `{}`                                                   |                                                     |
-| ingress.enabled                                                | bool   | `false`                                                |                                                     |
-| ingress.host                                                   | string | `""`                                                   |                                                     |
-| ingress.name                                                   | string | `"litmus-ingress"`                                     |                                                     |
-| ingress.tls                                                    | list   | `[]`                                                   |                                                     |
-| mongo.containerPort                                            | int    | `27017`                                                |                                                     |
-| mongo.image.pullPolicy                                         | string | `"Always"`                                             |                                                     |
-| mongo.image.repository                                         | string | `"mongo"`                                              |                                                     |
-| mongo.image.tag                                                | string | `"4.2.8"`                                              |                                                     |
-| mongo.persistence.accessMode                                   | string | `"ReadWriteOnce"`                                      |                                                     |
-| mongo.persistence.size                                         | string | `"20Gi"`                                               |                                                     |
-| mongo.replicas                                                 | int    | `1`                                                    |                                                     |
-| mongo.resources                                                | object | `{}`                                                   |                                                     |
-| mongo.service.port                                             | int    | `27017`                                                |                                                     |
-| mongo.service.targetPort                                       | int    | `27017`                                                |                                                     |
-| mongo.service.type                                             | string | `"ClusterIP"`                                          |                                                     |
-| portal.frontend.containerPort                                  | int    | `8080`                                                 |                                                     |
-| portal.frontend.image.pullPolicy                               | string | `"Always"`                                             |                                                     |
-| portal.frontend.image.repository                               | string | `"litmuschaos/litmusportal-frontend"`                  |                                                     |
-| portal.frontend.image.tag                                      | string | `"2.0.0-Beta3"`                                        |                                                     |
-| portal.frontend.replicas                                       | int    | `1`                                                    |                                                     |
-| portal.frontend.resources                                      | object | `{}`                                                   |                                                     |
-| portal.frontend.service.port                                   | int    | `9091`                                                 |                                                     |
-| portal.frontend.service.targetPort                             | int    | `8080`                                                 |                                                     |
-| portal.frontend.service.type                                   | string | `"NodePort"`                                           |                                                     |
-| portal.server.authServer.containerPort                         | int    | `3000`                                                 |                                                     |
-| portal.server.authServer.env.ADMIN_PASSWORD                    | string | `"litmus"`                                             |                                                     |
-| portal.server.authServer.env.ADMIN_USERNAME                    | string | `"admin"`                                              |                                                     |
-| portal.server.authServer.image.pullPolicy                      | string | `"Always"`                                             |                                                     |
-| portal.server.authServer.image.repository                      | string | `"litmuschaos/litmusportal-auth-server"`               |                                                     |
-| portal.server.authServer.image.tag                             | string | `"2.0.0-Beta3"`                                        |                                                     |
-| portal.server.authServer.resources                             | object | `{}`                                                   |                                                     |
-| portal.server.graphqlServer.containerPort                      | int    | `8080`                                                 |                                                     |
-| portal.server.graphqlServer.env.ARGO_SERVER_IMAGE              | string | `"argoproj/argocli:v2.9.3"`                            |                                                     |
-| portal.server.graphqlServer.env.ARGO_WORKFLOW_CONTROLLER_IMAGE | string | `"argoproj/workflow-controller:v2.9.3"`                |                                                     |
-| portal.server.graphqlServer.env.ARGO_WORKFLOW_EXECUTOR_IMAGE   | string | `"argoproj/argoexec:v2.9.3"`                           |                                                     |
-| portal.server.graphqlServer.env.EVENT_TRACKER_IMAGE            | string | `"litmuschaos/litmusportal-event-tracker:2.0.0-Beta3"` |                                                     |
-| portal.server.graphqlServer.env.LITMUS_CHAOS_EXPORTER_IMAGE    | string | `"litmuschaos/chaos-exporter:1.13.3"`                  |                                                     |
-| portal.server.graphqlServer.env.LITMUS_CHAOS_OPERATOR_IMAGE    | string | `"litmuschaos/chaos-operator:1.13.3"`                  |                                                     |
-| portal.server.graphqlServer.env.LITMUS_CHAOS_RUNNER_IMAGE      | string | `"litmuschaos/chaos-runner:1.13.3"`                    |                                                     |
-| portal.server.graphqlServer.env.SELF_CLUSTER                   | string | `"true"`                                               |                                                     |
-| portal.server.graphqlServer.env.SERVER_SERVICE_NAME            | string | `"litmusportal-server-service"`                        |                                                     |
-| portal.server.graphqlServer.env.PORTAL_ENDPOINT                | string | `"http://litmusportal-server-service:9002"`            |                                                     |
-| portal.server.graphqlServer.env.SUBSCRIBER_IMAGE               | string | `"litmuschaos/litmusportal-subscriber:2.0.0-Beta3"`    |                                                     |
-| portal.server.graphqlServer.env.CONTAINER_RUNTIME_EXECUTOR     | string | `"k8sapi"`                                             |                                                     |
-| portal.server.graphqlServer.image.pullPolicy                   | string | `"Always"`                                             |                                                     |
-| portal.server.graphqlServer.image.repository                   | string | `"litmuschaos/litmusportal-server"`                    |                                                     |
-| portal.server.graphqlServer.image.tag                          | string | `"2.0.0-Beta3"`                                        |                                                     |
-| portal.server.graphqlServer.resources                          | object | `{}`                                                   |                                                     |
-| portal.server.replicas                                         | int    | `1`                                                    |                                                     |
-| portal.server.service.authServer.port                          | int    | `9003`                                                 |                                                     |
-| portal.server.service.authServer.targetPort                    | int    | `3000`                                                 |                                                     |
-| portal.server.service.graphqlServer.port                       | int    | `9002`                                                 |                                                     |
-| portal.server.service.graphqlServer.targetPort                 | int    | `8080`                                                 |                                                     |
-| portal.server.service.type                                     | string | `"NodePort"`                                           |                                                     |
-| portal.server.serviceAccountName                               | string | `"litmus-server-account"`                              |                                                     |
-| portalScope                                                    | string | `"cluster"`                                            |                                                     |
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| adminConfig.DBPASSWORD | string | `"1234"` |  |
+| adminConfig.DBUSER | string | `"admin"` |  |
+| adminConfig.DB_PORT | string | `"27017"` |  |
+| adminConfig.DB_SERVER | string | `""` | leave empty if uses Mongo DB deployed by this chart |
+| adminConfig.JWTSecret | string | `"litmus-portal@123"` |  |
+| imagePullSecrets | list | `[]` |  |
+| ingress.annotations | object | `{}` |  |
+| ingress.enabled | bool | `false` |  |
+| ingress.host | string | `""` |  |
+| ingress.name | string | `"litmus-ingress"` |  |
+| ingress.tls | list | `[]` |  |
+| mongo.containerPort | int | `27017` |  |
+| mongo.image.pullPolicy | string | `"Always"` |  |
+| mongo.image.repository | string | `"mongo"` |  |
+| mongo.image.tag | string | `"4.2.8"` |  |
+| mongo.persistence.accessMode | string | `"ReadWriteOnce"` |  |
+| mongo.persistence.size | string | `"20Gi"` |  |
+| mongo.replicas | int | `1` |  |
+| mongo.resources | object | `{}` |  |
+| mongo.service.port | int | `27017` |  |
+| mongo.service.targetPort | int | `27017` |  |
+| mongo.service.type | string | `"ClusterIP"` |  |
+| portal.frontend.containerPort | int | `8080` |  |
+| portal.frontend.image.pullPolicy | string | `"Always"` |  |
+| portal.frontend.image.repository | string | `"litmuschaos/litmusportal-frontend"` |  |
+| portal.frontend.image.tag | string | `"2.0.0-Beta3"` |  |
+| portal.frontend.replicas | int | `1` |  |
+| portal.frontend.resources | object | `{}` |  |
+| portal.frontend.service.port | int | `9091` |  |
+| portal.frontend.service.targetPort | int | `8080` |  |
+| portal.frontend.service.type | string | `"NodePort"` |  |
+| portal.server.authServer.containerPort | int | `3000` |  |
+| portal.server.authServer.env.ADMIN_PASSWORD | string | `"litmus"` |  |
+| portal.server.authServer.env.ADMIN_USERNAME | string | `"admin"` |  |
+| portal.server.authServer.image.pullPolicy | string | `"Always"` |  |
+| portal.server.authServer.image.repository | string | `"litmuschaos/litmusportal-auth-server"` |  |
+| portal.server.authServer.image.tag | string | `"2.0.0-Beta3"` |  |
+| portal.server.authServer.resources | object | `{}` |  |
+| portal.server.graphqlServer.containerPort | int | `8080` |  |
+| portal.server.graphqlServer.env.ARGO_SERVER_IMAGE | string | `"argoproj/argocli:v2.9.3"` |  |
+| portal.server.graphqlServer.env.ARGO_WORKFLOW_CONTROLLER_IMAGE | string | `"argoproj/workflow-controller:v2.9.3"` |  |
+| portal.server.graphqlServer.env.ARGO_WORKFLOW_EXECUTOR_IMAGE | string | `"argoproj/argoexec:v2.9.3"` |  |
+| portal.server.graphqlServer.env.CONTAINER_RUNTIME_EXECUTOR | string | `"k8sapi"` |  |
+| portal.server.graphqlServer.env.EVENT_TRACKER_IMAGE | string | `"litmuschaos/litmusportal-event-tracker:2.0.0-Beta3"` |  |
+| portal.server.graphqlServer.env.LITMUS_CHAOS_EXPORTER_IMAGE | string | `"litmuschaos/chaos-exporter:1.13.3"` |  |
+| portal.server.graphqlServer.env.LITMUS_CHAOS_OPERATOR_IMAGE | string | `"litmuschaos/chaos-operator:1.13.3"` |  |
+| portal.server.graphqlServer.env.LITMUS_CHAOS_RUNNER_IMAGE | string | `"litmuschaos/chaos-runner:1.13.3"` |  |
+| portal.server.graphqlServer.env.PORTAL_ENDPOINT | string | `"http://litmusportal-server-service:9002"` |  |
+| portal.server.graphqlServer.env.SELF_CLUSTER | string | `"true"` |  |
+| portal.server.graphqlServer.env.SERVER_SERVICE_NAME | string | `"litmusportal-server-service"` |  |
+| portal.server.graphqlServer.env.SUBSCRIBER_IMAGE | string | `"litmuschaos/litmusportal-subscriber:2.0.0-Beta3"` |  |
+| portal.server.graphqlServer.image.pullPolicy | string | `"Always"` |  |
+| portal.server.graphqlServer.image.repository | string | `"litmuschaos/litmusportal-server"` |  |
+| portal.server.graphqlServer.image.tag | string | `"2.0.0-Beta3"` |  |
+| portal.server.graphqlServer.resources | object | `{}` |  |
+| portal.server.replicas | int | `1` |  |
+| portal.server.service.authServer.port | int | `9003` |  |
+| portal.server.service.authServer.targetPort | int | `3000` |  |
+| portal.server.service.graphqlServer.port | int | `9002` |  |
+| portal.server.service.graphqlServer.targetPort | int | `8080` |  |
+| portal.server.service.type | string | `"NodePort"` |  |
+| portal.server.serviceAccountName | string | `"litmus-server-account"` |  |
+| portalScope | string | `"cluster"` |  |
 
----
-
+----------------------------------------------
 Autogenerated from chart metadata using [helm-docs v1.5.0](https://github.com/norwoodj/helm-docs/releases/v1.5.0)

--- a/charts/litmus-2-0-0-beta/README.md
+++ b/charts/litmus-2-0-0-beta/README.md
@@ -8,15 +8,15 @@ A Helm chart to install litmus portal
 
 ## Maintainers
 
-| Name       | Email                         | Url |
-| ---------- | ----------------------------- | --- |
-| rajdas98   | raj.das@mayadata.io           |     |
-| ispeakc0de | shubham.chaudhary@mayadata.io |     |
-| jasstkn    | jasssstkn@yahoo.com           |     |
+| Name | Email | Url |
+| ---- | ------ | --- |
+| rajdas98 | raj.das@mayadata.io |  |
+| ispeakc0de | shubham.chaudhary@mayadata.io |  |
+| jasstkn | jasssstkn@yahoo.com |  |
 
 ## Source Code
 
-- <https://github.com/litmuschaos/litmus>
+* <https://github.com/litmuschaos/litmus>
 
 ## Requirements
 
@@ -31,77 +31,76 @@ $ helm repo add litmuschaos https://litmuschaos.github.io/litmus-helm/
 $ helm install litmus-portal litmuschaos/litmus-2-0-0-beta
 ```
 
-**_Note_**: This chart is in its beta release. To find it using `helm search` add `--devel` option.
+***Note***: This chart is in its beta release. To find it using `helm search` add `--devel` option.
 
 ## Values
 
-| Key                                                            | Type   | Default                                                | Description                                         |
-| -------------------------------------------------------------- | ------ | ------------------------------------------------------ | --------------------------------------------------- |
-| adminConfig.DBPASSWORD                                         | string | `"1234"`                                               |                                                     |
-| adminConfig.DBUSER                                             | string | `"admin"`                                              |                                                     |
-| adminConfig.DB_PORT                                            | string | `"27017"`                                              |                                                     |
-| adminConfig.DB_SERVER                                          | string | `""`                                                   | leave empty if uses Mongo DB deployed by this chart |
-| adminConfig.JWTSecret                                          | string | `"litmus-portal@123"`                                  |                                                     |
-| imagePullSecrets                                               | list   | `[]`                                                   |                                                     |
-| ingress.annotations                                            | object | `{}`                                                   |                                                     |
-| ingress.enabled                                                | bool   | `false`                                                |                                                     |
-| ingress.host                                                   | string | `""`                                                   |                                                     |
-| ingress.name                                                   | string | `"litmus-ingress"`                                     |                                                     |
-| ingress.tls                                                    | list   | `[]`                                                   |                                                     |
-| mongo.containerPort                                            | int    | `27017`                                                |                                                     |
-| mongo.image.pullPolicy                                         | string | `"Always"`                                             |                                                     |
-| mongo.image.repository                                         | string | `"mongo"`                                              |                                                     |
-| mongo.image.tag                                                | string | `"4.2.8"`                                              |                                                     |
-| mongo.persistence.accessMode                                   | string | `"ReadWriteOnce"`                                      |                                                     |
-| mongo.persistence.size                                         | string | `"20Gi"`                                               |                                                     |
-| mongo.replicas                                                 | int    | `1`                                                    |                                                     |
-| mongo.resources                                                | object | `{}`                                                   |                                                     |
-| mongo.service.port                                             | int    | `27017`                                                |                                                     |
-| mongo.service.targetPort                                       | int    | `27017`                                                |                                                     |
-| mongo.service.type                                             | string | `"ClusterIP"`                                          |                                                     |
-| portal.frontend.containerPort                                  | int    | `8080`                                                 |                                                     |
-| portal.frontend.image.pullPolicy                               | string | `"Always"`                                             |                                                     |
-| portal.frontend.image.repository                               | string | `"litmuschaos/litmusportal-frontend"`                  |                                                     |
-| portal.frontend.image.tag                                      | string | `"2.0.0-Beta3"`                                        |                                                     |
-| portal.frontend.replicas                                       | int    | `1`                                                    |                                                     |
-| portal.frontend.resources                                      | object | `{}`                                                   |                                                     |
-| portal.frontend.service.port                                   | int    | `9091`                                                 |                                                     |
-| portal.frontend.service.targetPort                             | int    | `8080`                                                 |                                                     |
-| portal.frontend.service.type                                   | string | `"NodePort"`                                           |                                                     |
-| portal.server.authServer.containerPort                         | int    | `3000`                                                 |                                                     |
-| portal.server.authServer.env.ADMIN_PASSWORD                    | string | `"litmus"`                                             |                                                     |
-| portal.server.authServer.env.ADMIN_USERNAME                    | string | `"admin"`                                              |                                                     |
-| portal.server.authServer.image.pullPolicy                      | string | `"Always"`                                             |                                                     |
-| portal.server.authServer.image.repository                      | string | `"litmuschaos/litmusportal-auth-server"`               |                                                     |
-| portal.server.authServer.image.tag                             | string | `"2.0.0-Beta3"`                                        |                                                     |
-| portal.server.authServer.resources                             | object | `{}`                                                   |                                                     |
-| portal.server.graphqlServer.containerPort                      | int    | `8080`                                                 |                                                     |
-| portal.server.graphqlServer.env.ARGO_SERVER_IMAGE              | string | `"argoproj/argocli:v2.9.3"`                            |                                                     |
-| portal.server.graphqlServer.env.ARGO_WORKFLOW_CONTROLLER_IMAGE | string | `"argoproj/workflow-controller:v2.9.3"`                |                                                     |
-| portal.server.graphqlServer.env.ARGO_WORKFLOW_EXECUTOR_IMAGE   | string | `"argoproj/argoexec:v2.9.3"`                           |                                                     |
-| portal.server.graphqlServer.env.CONTAINER_RUNTIME_EXECUTOR     | string | `"k8sapi"`                                             |                                                     |
-| portal.server.graphqlServer.env.HUB_BRANCH_NAME                | string | `"v1.13.x"`                                            |                                                     |
-| portal.server.graphqlServer.env.EVENT_TRACKER_IMAGE            | string | `"litmuschaos/litmusportal-event-tracker:2.0.0-Beta3"` |                                                     |
-| portal.server.graphqlServer.env.LITMUS_CHAOS_EXPORTER_IMAGE    | string | `"litmuschaos/chaos-exporter:1.13.3"`                  |                                                     |
-| portal.server.graphqlServer.env.LITMUS_CHAOS_OPERATOR_IMAGE    | string | `"litmuschaos/chaos-operator:1.13.3"`                  |                                                     |
-| portal.server.graphqlServer.env.LITMUS_CHAOS_RUNNER_IMAGE      | string | `"litmuschaos/chaos-runner:1.13.3"`                    |                                                     |
-| portal.server.graphqlServer.env.PORTAL_ENDPOINT                | string | `"http://litmusportal-server-service:9002"`            |                                                     |
-| portal.server.graphqlServer.env.SELF_CLUSTER                   | string | `"true"`                                               |                                                     |
-| portal.server.graphqlServer.env.SERVER_SERVICE_NAME            | string | `"litmusportal-server-service"`                        |                                                     |
-| portal.server.graphqlServer.env.SUBSCRIBER_IMAGE               | string | `"litmuschaos/litmusportal-subscriber:2.0.0-Beta3"`    |                                                     |
-| portal.server.graphqlServer.image.pullPolicy                   | string | `"Always"`                                             |                                                     |
-| portal.server.graphqlServer.image.repository                   | string | `"litmuschaos/litmusportal-server"`                    |                                                     |
-| portal.server.graphqlServer.image.tag                          | string | `"2.0.0-Beta3"`                                        |                                                     |
-| portal.server.graphqlServer.resources                          | object | `{}`                                                   |                                                     |
-| portal.server.replicas                                         | int    | `1`                                                    |                                                     |
-| portal.server.service.authServer.port                          | int    | `9003`                                                 |                                                     |
-| portal.server.service.authServer.targetPort                    | int    | `3000`                                                 |                                                     |
-| portal.server.service.graphqlServer.port                       | int    | `9002`                                                 |                                                     |
-| portal.server.service.graphqlServer.targetPort                 | int    | `8080`                                                 |                                                     |
-| portal.server.service.type                                     | string | `"NodePort"`                                           |                                                     |
-| portal.server.serviceAccountName                               | string | `"litmus-server-account"`                              |                                                     |
-| portalScope                                                    | string | `"cluster"`                                            |                                                     |
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| adminConfig.DBPASSWORD | string | `"1234"` |  |
+| adminConfig.DBUSER | string | `"admin"` |  |
+| adminConfig.DB_PORT | string | `"27017"` |  |
+| adminConfig.DB_SERVER | string | `""` | leave empty if uses Mongo DB deployed by this chart |
+| adminConfig.JWTSecret | string | `"litmus-portal@123"` |  |
+| imagePullSecrets | list | `[]` |  |
+| ingress.annotations | object | `{}` |  |
+| ingress.enabled | bool | `false` |  |
+| ingress.host | string | `""` |  |
+| ingress.name | string | `"litmus-ingress"` |  |
+| ingress.tls | list | `[]` |  |
+| mongo.containerPort | int | `27017` |  |
+| mongo.image.pullPolicy | string | `"Always"` |  |
+| mongo.image.repository | string | `"mongo"` |  |
+| mongo.image.tag | string | `"4.2.8"` |  |
+| mongo.persistence.accessMode | string | `"ReadWriteOnce"` |  |
+| mongo.persistence.size | string | `"20Gi"` |  |
+| mongo.replicas | int | `1` |  |
+| mongo.resources | object | `{}` |  |
+| mongo.service.port | int | `27017` |  |
+| mongo.service.targetPort | int | `27017` |  |
+| mongo.service.type | string | `"ClusterIP"` |  |
+| portal.frontend.containerPort | int | `8080` |  |
+| portal.frontend.image.pullPolicy | string | `"Always"` |  |
+| portal.frontend.image.repository | string | `"litmuschaos/litmusportal-frontend"` |  |
+| portal.frontend.image.tag | string | `"2.0.0-Beta3"` |  |
+| portal.frontend.replicas | int | `1` |  |
+| portal.frontend.resources | object | `{}` |  |
+| portal.frontend.service.port | int | `9091` |  |
+| portal.frontend.service.targetPort | int | `8080` |  |
+| portal.frontend.service.type | string | `"NodePort"` |  |
+| portal.server.authServer.containerPort | int | `3000` |  |
+| portal.server.authServer.env.ADMIN_PASSWORD | string | `"litmus"` |  |
+| portal.server.authServer.env.ADMIN_USERNAME | string | `"admin"` |  |
+| portal.server.authServer.image.pullPolicy | string | `"Always"` |  |
+| portal.server.authServer.image.repository | string | `"litmuschaos/litmusportal-auth-server"` |  |
+| portal.server.authServer.image.tag | string | `"2.0.0-Beta3"` |  |
+| portal.server.authServer.resources | object | `{}` |  |
+| portal.server.graphqlServer.containerPort | int | `8080` |  |
+| portal.server.graphqlServer.env.ARGO_SERVER_IMAGE | string | `"argoproj/argocli:v2.9.3"` |  |
+| portal.server.graphqlServer.env.ARGO_WORKFLOW_CONTROLLER_IMAGE | string | `"argoproj/workflow-controller:v2.9.3"` |  |
+| portal.server.graphqlServer.env.ARGO_WORKFLOW_EXECUTOR_IMAGE | string | `"argoproj/argoexec:v2.9.3"` |  |
+| portal.server.graphqlServer.env.CONTAINER_RUNTIME_EXECUTOR | string | `"k8sapi"` |  |
+| portal.server.graphqlServer.env.EVENT_TRACKER_IMAGE | string | `"litmuschaos/litmusportal-event-tracker:2.0.0-Beta3"` |  |
+| portal.server.graphqlServer.env.HUB_BRANCH_NAME | string | `"v1.13.x"` |  |
+| portal.server.graphqlServer.env.LITMUS_CHAOS_EXPORTER_IMAGE | string | `"litmuschaos/chaos-exporter:1.13.3"` |  |
+| portal.server.graphqlServer.env.LITMUS_CHAOS_OPERATOR_IMAGE | string | `"litmuschaos/chaos-operator:1.13.3"` |  |
+| portal.server.graphqlServer.env.LITMUS_CHAOS_RUNNER_IMAGE | string | `"litmuschaos/chaos-runner:1.13.3"` |  |
+| portal.server.graphqlServer.env.PORTAL_ENDPOINT | string | `"http://litmusportal-server-service:9002"` |  |
+| portal.server.graphqlServer.env.SELF_CLUSTER | string | `"true"` |  |
+| portal.server.graphqlServer.env.SERVER_SERVICE_NAME | string | `"litmusportal-server-service"` |  |
+| portal.server.graphqlServer.env.SUBSCRIBER_IMAGE | string | `"litmuschaos/litmusportal-subscriber:2.0.0-Beta3"` |  |
+| portal.server.graphqlServer.image.pullPolicy | string | `"Always"` |  |
+| portal.server.graphqlServer.image.repository | string | `"litmuschaos/litmusportal-server"` |  |
+| portal.server.graphqlServer.image.tag | string | `"2.0.0-Beta3"` |  |
+| portal.server.graphqlServer.resources | object | `{}` |  |
+| portal.server.replicas | int | `1` |  |
+| portal.server.service.authServer.port | int | `9003` |  |
+| portal.server.service.authServer.targetPort | int | `3000` |  |
+| portal.server.service.graphqlServer.port | int | `9002` |  |
+| portal.server.service.graphqlServer.targetPort | int | `8080` |  |
+| portal.server.service.type | string | `"NodePort"` |  |
+| portal.server.serviceAccountName | string | `"litmus-server-account"` |  |
+| portalScope | string | `"cluster"` |  |
 
----
-
+----------------------------------------------
 Autogenerated from chart metadata using [helm-docs v1.5.0](https://github.com/norwoodj/helm-docs/releases/v1.5.0)

--- a/charts/litmus-2-0-0-beta/values.yaml
+++ b/charts/litmus-2-0-0-beta/values.yaml
@@ -18,7 +18,8 @@ imagePullSecrets: []
 ingress:
   enabled: false
   name: litmus-ingress
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
     # nginx.ingress.kubernetes.io/rewrite-target: /$1
@@ -72,6 +73,8 @@ portal:
         LITMUS_CHAOS_EXPORTER_IMAGE: "litmuschaos/chaos-exporter:1.13.3"
         SELF_CLUSTER: "true"
         SERVER_SERVICE_NAME: "litmusportal-server-service"
+        PORTAL_ENDPOINT: "http://litmusportal-server-service:9002"
+        CONTAINER_RUNTIME_EXECUTOR: "k8sapi"
       resources: {}
       # We usually recommend not to specify default resources and to leave this as a conscious
       # choice for the user. This also increases chances charts run on environments with little

--- a/charts/litmus-2-0-0-beta/values.yaml
+++ b/charts/litmus-2-0-0-beta/values.yaml
@@ -75,6 +75,7 @@ portal:
         SERVER_SERVICE_NAME: "litmusportal-server-service"
         PORTAL_ENDPOINT: "http://litmusportal-server-service:9002"
         CONTAINER_RUNTIME_EXECUTOR: "k8sapi"
+        HUB_BRANCH_NAME: "v1.13.x"
       resources: {}
       # We usually recommend not to specify default resources and to leave this as a conscious
       # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
Signed-off-by: ishangupta-ds <ishan@chaosnative.com>

#### What this PR does / why we need it:

* This PR adds environment variable for litmus 2.0 server
- `HUB_BRANCH_NAME` for the graphql server to be used for ChaosHubs feature.

   > Defaults to `v1.13.x`

#### Checklist

- [x] DCO signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

@ksatchit @rajdas98 @ispeakc0de @Jasstkn 