### PR TITLE
Added PORTAL_ENDPOINT variable when portal runs namespaced mode

### DIFF
--- a/charts/litmus-2-0-0-beta/Chart.yaml
+++ b/charts/litmus-2-0-0-beta/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.0.0"
 description: A Helm chart to install litmus portal
 name: litmus-2-0-0-beta
-version: 2.0.15-Beta4
+version: 2.0.16-Beta4
 kubeVersion: ">=1.16.0-0"
 home: https://litmuschaos.io
 sources:

--- a/charts/litmus-2-0-0-beta/README.md
+++ b/charts/litmus-2-0-0-beta/README.md
@@ -1,6 +1,6 @@
 # litmus-2-0-0-beta
 
-![Version: 2.0.15-Beta4](https://img.shields.io/badge/Version-2.0.15--Beta4-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 2.0.16-Beta4](https://img.shields.io/badge/Version-2.0.16--Beta4-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart to install litmus portal
 

--- a/charts/litmus-2-0-0-beta/templates/server-deployment.yaml
+++ b/charts/litmus-2-0-0-beta/templates/server-deployment.yaml
@@ -46,6 +46,10 @@ spec:
                   fieldPath: metadata.namespace
             - name: PORTAL_SCOPE
               value: {{ .Values.portalScope }}
+            {{- if eq .Values.portalScope "namespace" }}
+            - name: PORTAL_ENDPOINT
+              value: "http://{{ .Values.portal.server.graphqlServer.env.SERVER_SERVICE_NAME }}:{{ .Values.portal.server.service.graphqlServer.port }}"
+            {{- end }}
             - name: AGENT_SCOPE
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
PORTAL_ENDPOINT variable is required when Litmus Portal runs in namespaced mode. 
This is used to construct the GraphQL URL: https://github.com/litmuschaos/litmus/blob/c947580814668a8c85cf817e56ef08b2c8192764/litmus-portal/graphql-server/pkg/file_handlers/file_handlers.go#L66

Signed-off-by: Radu Domnu <radu.domnu@gmail.com>

<!--

* https://github.com/helm/helm/tree/master/docs/chart_best_practices

Following best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] DCO signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
