### PR TITLE
helm(1.13.5): updating charts for 1.13.5

### DIFF
--- a/charts/kubernetes-chaos/Chart.yaml
+++ b/charts/kubernetes-chaos/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.13.3"
+appVersion: "1.13.5"
 description: A Helm chart to install litmus chaos experiments for kubernetes category (chaos-chart)
 name: kubernetes-chaos
-version: 2.9.10
+version: 2.10.0
 home: https://litmuschaos.io
 sources:
   - https://github.com/litmuschaos/litmus

--- a/charts/kubernetes-chaos/README.md
+++ b/charts/kubernetes-chaos/README.md
@@ -30,12 +30,12 @@ A Helm chart to install litmus chaos experiments for kubernetes category (chaos-
 | fullnameOverride | string | `"k8s"` |  |
 | image.litmus.pullPolicy | string | `"Always"` |  |
 | image.litmus.repository | string | `"litmuschaos/ansible-runner"` |  |
-| image.litmus.tag | string | `"1.13.3"` |  |
+| image.litmus.tag | string | `"1.13.5"` |  |
 | image.litmusGO.pullPolicy | string | `"Always"` |  |
 | image.litmusGO.repository | string | `"litmuschaos/go-runner"` |  |
-| image.litmusGO.tag | string | `"1.13.3"` |  |
+| image.litmusGO.tag | string | `"1.13.5"` |  |
 | image.litmusLIBImage.repository | string | `"litmuschaos/go-runner"` |  |
-| image.litmusLIBImage.tag | string | `"1.13.3"` |  |
+| image.litmusLIBImage.tag | string | `"1.13.5"` |  |
 | image.networkChaos.tcImage | string | `"gaiadocker/iproute2"` |  |
 | image.pumba.libName | string | `"pumba"` |  |
 | image.resourceChaos.respository | string | `"alexeiled/stress-ng"` |  |

--- a/charts/kubernetes-chaos/README.md
+++ b/charts/kubernetes-chaos/README.md
@@ -1,6 +1,6 @@
 # kubernetes-chaos
 
-![Version: 2.9.11](https://img.shields.io/badge/Version-2.9.11-informational?style=flat-square) ![AppVersion: 1.13.3](https://img.shields.io/badge/AppVersion-1.13.3-informational?style=flat-square)
+![Version: 2.10.0](https://img.shields.io/badge/Version-2.10.0-informational?style=flat-square) ![AppVersion: 1.13.5](https://img.shields.io/badge/AppVersion-1.13.5-informational?style=flat-square)
 
 A Helm chart to install litmus chaos experiments for kubernetes category (chaos-chart)
 

--- a/charts/kubernetes-chaos/crds/chaosexperiment_crd.yaml
+++ b/charts/kubernetes-chaos/crds/chaosexperiment_crd.yaml
@@ -36,10 +36,10 @@ spec:
             x-kubernetes-preserve-unknown-fields: true
             type: object            
           spec:
-            x-kubernetes-preserve-unknown-fields: true
             type: object
             properties:
               definition:
+                x-kubernetes-preserve-unknown-fields: true
                 type: object
                 properties:
                   args:

--- a/charts/kubernetes-chaos/templates/disk-fill.yaml
+++ b/charts/kubernetes-chaos/templates/disk-fill.yaml
@@ -72,6 +72,11 @@ spec:
     - name: LIB_IMAGE
       value: "{{ .Values.image.litmusLIBImage.repository }}:{{ .Values.image.litmusLIBImage.tag }}"
 
+    # provide the data block size
+    # supported unit is KB
+    - name: DATA_BLOCK_SIZE
+      value: '256'
+
     - name: TARGET_PODS
       value: ''
 

--- a/charts/kubernetes-chaos/templates/kubelet-service-kill.yaml
+++ b/charts/kubernetes-chaos/templates/kubelet-service-kill.yaml
@@ -60,6 +60,9 @@ spec:
     - name: LIB
       value: 'litmus'
 
+    - name: NODE_LABEL
+      value: ''
+
     - name: LIB_IMAGE
       value: 'ubuntu:16.04'
 

--- a/charts/kubernetes-chaos/templates/node-cpu-hog.yaml
+++ b/charts/kubernetes-chaos/templates/node-cpu-hog.yaml
@@ -64,6 +64,9 @@ spec:
     # ENTER THE COMMA SEPARATED TARGET NODES NAME
     - name: TARGET_NODES
       value: ''
+
+    - name: NODE_LABEL
+      value: ''
     
     - name: LIB
       value: 'litmus'

--- a/charts/kubernetes-chaos/templates/node-drain.yaml
+++ b/charts/kubernetes-chaos/templates/node-drain.yaml
@@ -57,6 +57,9 @@ spec:
     - name: TARGET_NODE
       value: ''
 
+    - name: NODE_LABEL
+      value: ''
+
     - name: TOTAL_CHAOS_DURATION
       value: '60'
 

--- a/charts/kubernetes-chaos/templates/node-io-stress.yaml
+++ b/charts/kubernetes-chaos/templates/node-io-stress.yaml
@@ -77,7 +77,10 @@ spec:
 
     ## enter the comma separated target nodes name
     - name: TARGET_NODES
-      value: ''    
+      value: ''   
+
+    - name: NODE_LABEL
+      value: '' 
 
     # Period to wait before and after injection of chaos in sec
     - name: RAMP_TIME

--- a/charts/kubernetes-chaos/templates/node-memory-hog.yaml
+++ b/charts/kubernetes-chaos/templates/node-memory-hog.yaml
@@ -70,6 +70,9 @@ spec:
     - name: TARGET_NODES
       value: '' 
 
+    - name: NODE_LABEL
+      value: ''
+
     # Period to wait before injection of chaos in sec
     - name: RAMP_TIME
       value: ''

--- a/charts/kubernetes-chaos/templates/node-taint.yaml
+++ b/charts/kubernetes-chaos/templates/node-taint.yaml
@@ -58,6 +58,9 @@ spec:
     - name: TARGET_NODE
       value: ''
 
+    - name: NODE_LABEL
+      value: ''
+
     - name: TOTAL_CHAOS_DURATION
       value: '60'
 

--- a/charts/kubernetes-chaos/templates/pod-dns-error.yaml
+++ b/charts/kubernetes-chaos/templates/pod-dns-error.yaml
@@ -1,0 +1,101 @@
+{{ if not (has "pod-dns-error" .Values.experiments.disabled) }}
+---
+apiVersion: litmuschaos.io/v1alpha1
+description:
+  message: |
+    Pod DNS Error injects dns failure/error in target pod containers
+kind: ChaosExperiment
+metadata:
+  name: pod-dns-error
+  labels:
+    {{- include "kubernetes-chaos.labels" . | indent 4 }}
+spec:
+  definition:
+    scope: Namespaced
+    permissions:
+      - apiGroups:
+          - ""
+          - "batch"
+          - "apps"
+          - "apps.openshift.io"
+          - "argoproj.io"
+          - "litmuschaos.io"
+        resources:
+          - "jobs"
+          - "pods"
+          - "pods/log"
+          - "events"
+          - "replicationcontrollers"
+          - "deployments"
+          - "statefulsets"
+          - "daemonsets"
+          - "replicasets"
+          - "deploymentconfigs"
+          - "rollouts"
+          - "pods/exec"
+          - "chaosengines"
+          - "chaosexperiments"
+          - "chaosresults"
+        verbs:
+          - "create"
+          - "list"
+          - "get"
+          - "patch"
+          - "update"
+          - "delete"
+          - "deletecollection"
+    image: "{{ .Values.image.litmusGO.repository }}:{{ .Values.image.litmusGO.tag }}"
+    imagePullPolicy: {{ .Values.image.litmusGO.pullPolicy }}
+    args:
+    - -c
+    - ./experiments -name pod-dns-error
+    command:
+    - /bin/bash
+    env:
+
+    - name: TARGET_CONTAINER
+        value: ""
+
+      # provide lib image
+      - name: LIB_IMAGE
+        value: "{{ .Values.image.litmusLIBImage.repository }}:{{ .Values.image.litmusLIBImage.tag }}"
+
+      - name: TOTAL_CHAOS_DURATION
+        value: "60" # in seconds
+
+      # Time period to wait before and after injection of chaos in sec
+      - name: RAMP_TIME
+        value: ""
+
+      ## percentage of total pods to target
+      - name: PODS_AFFECTED_PERC
+        value: ""
+
+      - name: TARGET_PODS
+        value: ""
+
+      # provide the name of container runtime, it supports docker, containerd, crio
+      - name: CONTAINER_RUNTIME
+        value: "{{ .Values.environment.runtime }}"
+
+      # provide the socket file path
+      - name: SOCKET_PATH
+        value: "{{ .Values.environment.socketPath }}"
+
+      ## it defines the sequence of chaos execution for multiple target pods
+      ## supported values: serial, parallel
+      - name: SEQUENCE
+        value: "parallel"
+
+     # list of the target hostnames or kewywords eg. '["litmuschaos","chaosnative.io"]' . If empty all hostnames are targets
+      - name: TARGET_HOSTNAMES
+        value: ""
+
+      # can be either exact or substring, determines whether the dns query has to match exactly with one of the targets or can have any of the targets as substring
+      - name: MATCH_SCHEME
+        value: "exact"
+            
+    labels:
+      name: pod-dns-error
+      app.kubernetes.io/part-of: litmus
+{{ end }}

--- a/charts/kubernetes-chaos/templates/pod-dns-error.yaml
+++ b/charts/kubernetes-chaos/templates/pod-dns-error.yaml
@@ -54,46 +54,46 @@ spec:
     env:
 
     - name: TARGET_CONTAINER
-        value: ""
+      value: ""
 
-      # provide lib image
-      - name: LIB_IMAGE
-        value: "{{ .Values.image.litmusLIBImage.repository }}:{{ .Values.image.litmusLIBImage.tag }}"
+    # provide lib image
+    - name: LIB_IMAGE
+      value: "{{ .Values.image.litmusLIBImage.repository }}:{{ .Values.image.litmusLIBImage.tag }}"
 
-      - name: TOTAL_CHAOS_DURATION
-        value: "60" # in seconds
+    - name: TOTAL_CHAOS_DURATION
+      value: "60" # in seconds
 
-      # Time period to wait before and after injection of chaos in sec
-      - name: RAMP_TIME
-        value: ""
+    # Time period to wait before and after injection of chaos in sec
+    - name: RAMP_TIME
+      value: ""
 
-      ## percentage of total pods to target
-      - name: PODS_AFFECTED_PERC
-        value: ""
+    ## percentage of total pods to target
+    - name: PODS_AFFECTED_PERC
+      value: ""
 
-      - name: TARGET_PODS
-        value: ""
+    - name: TARGET_PODS
+      value: ""
 
-      # provide the name of container runtime, it supports docker, containerd, crio
-      - name: CONTAINER_RUNTIME
-        value: "{{ .Values.environment.runtime }}"
+    # provide the name of container runtime, it supports docker, containerd, crio
+    - name: CONTAINER_RUNTIME
+      value: "{{ .Values.environment.runtime }}"
 
-      # provide the socket file path
-      - name: SOCKET_PATH
-        value: "{{ .Values.environment.socketPath }}"
+    # provide the socket file path
+    - name: SOCKET_PATH
+      value: "{{ .Values.environment.socketPath }}"
 
-      ## it defines the sequence of chaos execution for multiple target pods
-      ## supported values: serial, parallel
-      - name: SEQUENCE
-        value: "parallel"
+    ## it defines the sequence of chaos execution for multiple target pods
+    ## supported values: serial, parallel
+    - name: SEQUENCE
+      value: "parallel"
 
-     # list of the target hostnames or kewywords eg. '["litmuschaos","chaosnative.io"]' . If empty all hostnames are targets
-      - name: TARGET_HOSTNAMES
-        value: ""
+    # list of the target hostnames or kewywords eg. '["litmuschaos","chaosnative.io"]' . If empty all hostnames are targets
+    - name: TARGET_HOSTNAMES
+      value: ""
 
-      # can be either exact or substring, determines whether the dns query has to match exactly with one of the targets or can have any of the targets as substring
-      - name: MATCH_SCHEME
-        value: "exact"
+    # can be either exact or substring, determines whether the dns query has to match exactly with one of the targets or can have any of the targets as substring
+    - name: MATCH_SCHEME
+      value: "exact"
             
     labels:
       name: pod-dns-error

--- a/charts/kubernetes-chaos/templates/pod-dns-spoof.yaml
+++ b/charts/kubernetes-chaos/templates/pod-dns-spoof.yaml
@@ -54,42 +54,42 @@ spec:
     env:
 
     - name: TARGET_CONTAINER
-        value: ""
+      value: ""
 
-      # provide lib image
-      - name: LIB_IMAGE
-        value: "{{ .Values.image.litmusLIBImage.repository }}:{{ .Values.image.litmusLIBImage.tag }}"
+    # provide lib image
+    - name: LIB_IMAGE
+      value: "{{ .Values.image.litmusLIBImage.repository }}:{{ .Values.image.litmusLIBImage.tag }}"
 
-      - name: TOTAL_CHAOS_DURATION
-        value: "60" # in seconds
+    - name: TOTAL_CHAOS_DURATION
+      value: "60" # in seconds
 
-      # Time period to wait before and after injection of chaos in sec
-      - name: RAMP_TIME
-        value: ""
+    # Time period to wait before and after injection of chaos in sec
+    - name: RAMP_TIME
+      value: ""
 
-      ## percentage of total pods to target
-      - name: PODS_AFFECTED_PERC
-        value: ""
+    ## percentage of total pods to target
+    - name: PODS_AFFECTED_PERC
+      value: ""
 
-      - name: TARGET_PODS
-        value: ""
+    - name: TARGET_PODS
+      value: ""
 
-      # provide the name of container runtime, it supports docker, containerd, crio
-      - name: CONTAINER_RUNTIME
-        value: "{{ .Values.environment.runtime }}"
+    # provide the name of container runtime, it supports docker, containerd, crio
+    - name: CONTAINER_RUNTIME
+      value: "{{ .Values.environment.runtime }}"
 
-      # provide the socket file path
-      - name: SOCKET_PATH
-        value: "{{ .Values.environment.socketPath }}"
+    # provide the socket file path
+    - name: SOCKET_PATH
+      value: "{{ .Values.environment.socketPath }}"
 
-      ## it defines the sequence of chaos execution for multiple target pods
-      ## supported values: serial, parallel
-      - name: SEQUENCE
-        value: "parallel"
+    ## it defines the sequence of chaos execution for multiple target pods
+    ## supported values: serial, parallel
+    - name: SEQUENCE
+      value: "parallel"
 
-      # map of the target hostnames eg. '{"abc.com":"spoofabc.com"}' . If empty no queries will be spoofed
-      - name: SPOOF_MAP
-        value: ""
+    # map of the target hostnames eg. '{"abc.com":"spoofabc.com"}' . If empty no queries will be spoofed
+    - name: SPOOF_MAP
+      value: ""
             
     labels:
       name: pod-dns-spoof

--- a/charts/kubernetes-chaos/templates/pod-dns-spoof.yaml
+++ b/charts/kubernetes-chaos/templates/pod-dns-spoof.yaml
@@ -1,0 +1,97 @@
+{{ if not (has "pod-dns-spoof" .Values.experiments.disabled) }}
+---
+apiVersion: litmuschaos.io/v1alpha1
+description:
+  message: |
+    Pod DNS Spoof can spoof particular dns requests in target pod container to desired target hostnames
+kind: ChaosExperiment
+metadata:
+  name: pod-dns-spoof
+  labels:
+    {{- include "kubernetes-chaos.labels" . | indent 4 }}
+spec:
+  definition:
+    scope: Namespaced
+    permissions:
+      - apiGroups:
+          - ""
+          - "batch"
+          - "apps"
+          - "apps.openshift.io"
+          - "argoproj.io"
+          - "litmuschaos.io"
+        resources:
+          - "jobs"
+          - "pods"
+          - "pods/log"
+          - "events"
+          - "replicationcontrollers"
+          - "deployments"
+          - "statefulsets"
+          - "daemonsets"
+          - "replicasets"
+          - "deploymentconfigs"
+          - "rollouts"
+          - "pods/exec"
+          - "chaosengines"
+          - "chaosexperiments"
+          - "chaosresults"
+        verbs:
+          - "create"
+          - "list"
+          - "get"
+          - "patch"
+          - "update"
+          - "delete"
+          - "deletecollection"
+    image: "{{ .Values.image.litmusGO.repository }}:{{ .Values.image.litmusGO.tag }}"
+    imagePullPolicy: {{ .Values.image.litmusGO.pullPolicy }}
+    args:
+    - -c
+    - ./experiments -name pod-dns-spoof
+    command:
+    - /bin/bash
+    env:
+
+    - name: TARGET_CONTAINER
+        value: ""
+
+      # provide lib image
+      - name: LIB_IMAGE
+        value: "{{ .Values.image.litmusLIBImage.repository }}:{{ .Values.image.litmusLIBImage.tag }}"
+
+      - name: TOTAL_CHAOS_DURATION
+        value: "60" # in seconds
+
+      # Time period to wait before and after injection of chaos in sec
+      - name: RAMP_TIME
+        value: ""
+
+      ## percentage of total pods to target
+      - name: PODS_AFFECTED_PERC
+        value: ""
+
+      - name: TARGET_PODS
+        value: ""
+
+      # provide the name of container runtime, it supports docker, containerd, crio
+      - name: CONTAINER_RUNTIME
+        value: "{{ .Values.environment.runtime }}"
+
+      # provide the socket file path
+      - name: SOCKET_PATH
+        value: "{{ .Values.environment.socketPath }}"
+
+      ## it defines the sequence of chaos execution for multiple target pods
+      ## supported values: serial, parallel
+      - name: SEQUENCE
+        value: "parallel"
+
+      # map of the target hostnames eg. '{"abc.com":"spoofabc.com"}' . If empty no queries will be spoofed
+      - name: SPOOF_MAP
+        value: ""
+            
+    labels:
+      name: pod-dns-spoof
+      app.kubernetes.io/part-of: litmus
+{{ end }}

--- a/charts/kubernetes-chaos/values.yaml
+++ b/charts/kubernetes-chaos/values.yaml
@@ -11,12 +11,12 @@ customLabels: {}
 image:
   litmus:
     repository: litmuschaos/ansible-runner
-    tag: 1.13.3
+    tag: 1.13.5
     pullPolicy: Always
 
   litmusGO:
     repository: litmuschaos/go-runner
-    tag: 1.13.3
+    tag: 1.13.5
     pullPolicy: Always
 
   pumba:
@@ -24,7 +24,7 @@ image:
 
   litmusLIBImage:
     repository: litmuschaos/go-runner
-    tag: 1.13.3
+    tag: 1.13.5
 
   networkChaos:
     tcImage: gaiadocker/iproute2

--- a/charts/litmus/Chart.yaml
+++ b/charts/litmus/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.13.3"
+appVersion: "1.13.5"
 description: A Helm chart to install litmus infra components on Kubernetes
 name: litmus
-version: 1.13.8
+version: 1.14.0
 home: https://litmuschaos.io
 sources:
   - https://github.com/litmuschaos/litmus

--- a/charts/litmus/README.md
+++ b/charts/litmus/README.md
@@ -1,6 +1,6 @@
 # litmus
 
-![Version: 1.13.9](https://img.shields.io/badge/Version-1.13.9-informational?style=flat-square) ![AppVersion: 1.13.3](https://img.shields.io/badge/AppVersion-1.13.3-informational?style=flat-square)
+![Version: 1.14.0](https://img.shields.io/badge/Version-1.14.0-informational?style=flat-square) ![AppVersion: 1.13.5](https://img.shields.io/badge/AppVersion-1.13.5-informational?style=flat-square)
 
 A Helm chart to install litmus infra components on Kubernetes
 

--- a/charts/litmus/README.md
+++ b/charts/litmus/README.md
@@ -27,7 +27,7 @@ A Helm chart to install litmus infra components on Kubernetes
 | exporter.enabled | bool | `false` |  |
 | exporter.image.pullPolicy | string | `"Always"` |  |
 | exporter.image.repository | string | `"litmuschaos/chaos-exporter"` |  |
-| exporter.image.tag | string | `"1.13.3"` |  |
+| exporter.image.tag | string | `"1.13.5"` |  |
 | exporter.nodeSelector | object | `{}` |  |
 | exporter.resources | object | `{}` |  |
 | exporter.service.annotations | object | `{}` |  |
@@ -46,14 +46,14 @@ A Helm chart to install litmus infra components on Kubernetes
 | nodeSelector | object | `{}` |  |
 | operator.image.pullPolicy | string | `"Always"` |  |
 | operator.image.repository | string | `"litmuschaos/chaos-operator"` |  |
-| operator.image.tag | string | `"1.13.3"` |  |
+| operator.image.tag | string | `"1.13.5"` |  |
 | operatorMode | string | `"standard"` |  |
 | operatorName | string | `"chaos-operator"` |  |
 | policies.monitoring.disabled | bool | `false` |  |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | runner.image.repository | string | `"litmuschaos/chaos-runner"` |  |
-| runner.image.tag | string | `"1.13.3"` |  |
+| runner.image.tag | string | `"1.13.5"` |  |
 | service.port | int | `80` |  |
 | service.type | string | `"ClusterIP"` |  |
 | tolerations | list | `[]` |  |

--- a/charts/litmus/crds/chaosengine_crd.yaml
+++ b/charts/litmus/crds/chaosengine_crd.yaml
@@ -84,6 +84,29 @@ spec:
                             value:
                               type: string
                               minLength: 1
+                      tolerations:
+                        description: Pod's tolerations.
+                        items:
+                          description: The pod with this Toleration tolerates any taint matches the <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect to match. Empty means all effects.
+                              type: string
+                            key:
+                              description: Taint key the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists.
+                              type: string
+                            operator:
+                              description: Operators are Exists or Equal. Defaults to Equal.
+                              type: string
+                            tolerationSeconds:
+                              description: Period of time the toleration tolerates the taint.
+                              format: int64
+                              type: integer
+                            value:
+                              description: If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
               experiments:
                 type: array
                 items:
@@ -226,6 +249,7 @@ spec:
                               data:
                                 type: string
                         components:
+                          x-kubernetes-preserve-unknown-fields: true 
                           type: object
                           properties:
                             statusCheckTimeouts:
@@ -237,7 +261,17 @@ spec:
                                   type: integer
                             nodeSelector:
                               type: object
-                              minLength: 1
+                              additionalProperties:
+                                type: string
+                                properties:
+                                  key:
+                                    type: string
+                                    minLength: 1
+                                    allowEmptyValue: false
+                                  value:
+                                    type: string
+                                    minLength: 1
+                                    allowEmptyValue: false
                             experimentImage:
                               type: string
                             env:
@@ -386,6 +420,29 @@ spec:
                                     type: string
                                     minLength: 1
                                     allowEmptyValue: false
+                            tolerations:
+                              description: Pod's tolerations.
+                              items:
+                                description: The pod with this Toleration tolerates any taint matches the <key,value,effect> using the matching operator <operator>.
+                                properties:
+                                  effect:
+                                    description: Effect to match. Empty means all effects.
+                                    type: string
+                                  key:
+                                    description: Taint key the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists.
+                                    type: string
+                                  operator:
+                                    description: Operators are Exists or Equal. Defaults to Equal.
+                                    type: string
+                                  tolerationSeconds:
+                                    description: Period of time the toleration tolerates the taint.
+                                    format: int64
+                                    type: integer
+                                  value:
+                                    description: If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                    type: string
+                                type: object
+                              type: array
 
           status:
             x-kubernetes-preserve-unknown-fields: true

--- a/charts/litmus/crds/chaosexperiment_crd.yaml
+++ b/charts/litmus/crds/chaosexperiment_crd.yaml
@@ -36,10 +36,10 @@ spec:
             x-kubernetes-preserve-unknown-fields: true
             type: object            
           spec:
-            x-kubernetes-preserve-unknown-fields: true
             type: object
             properties:
               definition:
+                x-kubernetes-preserve-unknown-fields: true
                 type: object
                 properties:
                   args:

--- a/charts/litmus/values.yaml
+++ b/charts/litmus/values.yaml
@@ -15,12 +15,12 @@ replicaCount: 1
 operator:
   image:
     repository: litmuschaos/chaos-operator
-    tag: 1.13.3
+    tag: 1.13.5
     pullPolicy: Always
 runner:
   image:
     repository: litmuschaos/chaos-runner
-    tag: 1.13.3
+    tag: 1.13.5
 
 service:
   type: ClusterIP
@@ -75,7 +75,7 @@ exporter:
     additionalLabels: {}
   image:
     repository: litmuschaos/chaos-exporter
-    tag: 1.13.3
+    tag: 1.13.5
     pullPolicy: Always
   service:
     type: ClusterIP


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham@chaosnative.com>

<!--

* https://github.com/helm/helm/tree/master/docs/chart_best_practices

Following best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

- updating charts for the litmus 1.13.5 version
- adding pod-dns-spoof and pod-dns-error experiments
- updating crds for the latest changes

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] DCO signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
