### PR TITLE
Add value for setting mongo service account

### DIFF
--- a/charts/litmus-2-0-0-beta/Chart.yaml
+++ b/charts/litmus-2-0-0-beta/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.0.0"
 description: A Helm chart to install litmus portal
 name: litmus-2-0-0-beta
-version: 2.0.22-Beta8
+version: 2.0.23-Beta8
 kubeVersion: ">=1.16.0-0"
 home: https://litmuschaos.io
 sources:

--- a/charts/litmus-2-0-0-beta/README.md
+++ b/charts/litmus-2-0-0-beta/README.md
@@ -1,6 +1,6 @@
 # litmus-2-0-0-beta
 
-![Version: 2.0.22-Beta8](https://img.shields.io/badge/Version-2.0.22--Beta8-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 2.0.23-Beta8](https://img.shields.io/badge/Version-2.0.23--Beta8-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart to install litmus portal
 

--- a/charts/litmus-2-0-0-beta/templates/mongo-sts.yaml
+++ b/charts/litmus-2-0-0-beta/templates/mongo-sts.yaml
@@ -24,6 +24,9 @@ spec:
       imagePullSecrets:
         {{ toYaml .Values.image.imagePullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.mongo.serviceAccountName }}
+      serviceAccountName: {{ .Values.mongo.serviceAccountName }}
+      {{- end }}
       containers:
         - name: mongo
           image: {{ .Values.image.imageRegistryName }}/{{ .Values.mongo.image.repository }}:{{ .Values.mongo.image.tag }}

--- a/charts/litmus-2-0-0-beta/values.yaml
+++ b/charts/litmus-2-0-0-beta/values.yaml
@@ -147,6 +147,8 @@ mongo:
     type: ClusterIP
     port: 27017
     targetPort: 27017
+  # Service account to be used by mongo pods
+  # serviceAccountName: "mongo-service-account"
 
 # OpenShift specific configuration
 openshift:


### PR DESCRIPTION
This adds a simple option that allows users to set the service account
used by mongo. This service account must be created by the user. If this
field is omitted, no service account is configured for mongo.

Signed-off-by: Nikolas Skoufis <nskoufis@seek.com.au>

@rajdas98 @ispeakc0de @Jasstkn 

#### What this PR does / why we need it:
Adds an optional service account for the mongo statefulset pods, which enables users of PSPs to provide this pod with the correct permissions.

#### Which issue this PR fixes
- fixes #136 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] DCO signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
