### PR TITLE
Allow ingress path to be configurable

### DIFF
--- a/charts/litmus-2-0-0-beta/Chart.yaml
+++ b/charts/litmus-2-0-0-beta/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.0.0"
 description: A Helm chart to install litmus portal
 name: litmus-2-0-0-beta
-version: 2.0.23-Beta8
+version: 2.0.24-Beta8
 kubeVersion: ">=1.16.0-0"
 home: https://litmuschaos.io
 sources:

--- a/charts/litmus-2-0-0-beta/README.md
+++ b/charts/litmus-2-0-0-beta/README.md
@@ -1,6 +1,6 @@
 # litmus-2-0-0-beta
 
-![Version: 2.0.23-Beta8](https://img.shields.io/badge/Version-2.0.23--Beta8-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 2.0.23-Beta8](https://img.shields.io/badge/Version-2.0.24--Beta8-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart to install litmus portal
 

--- a/charts/litmus-2-0-0-beta/README.md
+++ b/charts/litmus-2-0-0-beta/README.md
@@ -50,6 +50,7 @@ $ helm install litmus-portal litmuschaos/litmus-2-0-0-beta
 | ingress.host | string | `""` |  |
 | ingress.name | string | `"litmus-ingress"` |  |
 | ingress.tls | list | `[]` |  |
+| ingress.path | string | `/(*)` |  |
 | mongo.containerPort | int | `27017` |  |
 | mongo.image.pullPolicy | string | `"Always"` |  |
 | mongo.image.repository | string | `"mongo"` |  |

--- a/charts/litmus-2-0-0-beta/templates/ingress.yaml
+++ b/charts/litmus-2-0-0-beta/templates/ingress.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{ $fullName := include "litmus-portal.fullname" . }}
+{{- $ingressPath := .Values.ingress.path -}}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
 {{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
@@ -37,14 +38,14 @@ spec:
   {{- end }}
     {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
       paths:
-      - path: /(.*)
+      - path: {{ $ingressPath }}
         pathType: ImplementationSpecific
         backend:
           service:
             name: litmusportal-frontend-service
             port:
               number: 9091
-      - path: /backend/(.*)
+      - path: /backend{{ $ingressPath }}
         pathType: ImplementationSpecific
         backend:
           service:
@@ -53,11 +54,11 @@ spec:
               number: 9002
     {{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
       paths:
-      - path: /(.*)
+      - path: {{ $ingressPath }}
         backend:
           serviceName: litmusportal-frontend-service
           servicePort: 9091
-      - path: /backend/(.*)
+      - path: /backend{{ $ingressPath }}
         backend:
           serviceName: litmusportal-server-service
           servicePort: 9002


### PR DESCRIPTION
<!--

* https://github.com/helm/helm/tree/master/docs/chart_best_practices

Following best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Allows the ingress path to be configurable, which it usually is on most helm charts I've encountered. My team had to manually install the charts on our local to change the path to the one we want. This makes it much more convenient. 

LMK if it looks good. Thanks!

#### Which issue this PR fixes
  - fixes #138 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] DCO signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
