### PR TITLE
Add required security context to mongo pod

### DIFF
--- a/charts/litmus-2-0-0-beta/Chart.yaml
+++ b/charts/litmus-2-0-0-beta/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.0.0"
 description: A Helm chart to install litmus portal
 name: litmus-2-0-0-beta
-version: 2.0.23-Beta8
+version: 2.0.24-Beta8
 kubeVersion: ">=1.16.0-0"
 home: https://litmuschaos.io
 sources:

--- a/charts/litmus-2-0-0-beta/README.md
+++ b/charts/litmus-2-0-0-beta/README.md
@@ -1,6 +1,6 @@
 # litmus-2-0-0-beta
 
-![Version: 2.0.23-Beta8](https://img.shields.io/badge/Version-2.0.23--Beta8-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 2.0.24-Beta8](https://img.shields.io/badge/Version-2.0.24--Beta8-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart to install litmus portal
 

--- a/charts/litmus-2-0-0-beta/templates/mongo-sts.yaml
+++ b/charts/litmus-2-0-0-beta/templates/mongo-sts.yaml
@@ -27,6 +27,8 @@ spec:
       {{- if .Values.mongo.serviceAccountName }}
       serviceAccountName: {{ .Values.mongo.serviceAccountName }}
       {{- end }}
+      securityContext:
+        runAsNonRoot: false
       containers:
         - name: mongo
           image: {{ .Values.image.imageRegistryName }}/{{ .Values.mongo.image.repository }}:{{ .Values.mongo.image.tag }}
@@ -34,6 +36,12 @@ spec:
             - containerPort: {{ .Values.mongo.containerPort }}
               name: http
           imagePullPolicy: {{ .Values.mongo.image.pullPolicy }}
+          securityContext:
+            capabilities:
+              add:
+                - CHOWN
+                - SETUID
+                - SETGID
           volumeMounts:
             - name: mongo-persistent-storage
               mountPath: /data/db


### PR DESCRIPTION
This pod runs as root, and requires CHOWN, SETUID and SETGID to work
properly. These should be declared on the security context of the
pod/container in order for the correct PSP to be selected at admission
time, if in use.

Signed-off-by: Nikolas Skoufis <nskoufis@seek.com.au>

@Jasstkn 
@rajdas98 
@ispeakc0de 

#### What this PR does / why we need it:
Adds security context parameters required when using a PSP

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #140 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] DCO signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
