### PR TITLE
Add 1.21.1 k8s cluster, update minor version and kind itself

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       - run:
           name: Install kind
           command: |
-            curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.10.0/kind-linux-amd64
+            curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
             chmod +x ./kind
             sudo mv kind /usr/local/bin/
       - run:
@@ -109,5 +109,5 @@ workflows:
               ignore: gh-pages
           matrix:
             parameters:
-              kubernetes_version: [1.16.15, 1.17.17, 1.18.15, 1.19.7, 1.20.2]
+              kubernetes_version: [1.16.15, 1.17.17, 1.18.19, 1.19.11, 1.20.7, 1.21.1]
               chart: [litmus-2-0-0-beta, litmus, kubernetes-chaos, kube-aws]


### PR DESCRIPTION
Signed-off-by: Jasstkn <jasssstkn@yahoo.com>

#### What this PR does / why we need it:
- Add 1.21.1 Kubernetes version to run tests against
- Bump to the latest version for 1.17-1.20 Kubernetes
- Bump kind itself to 0.11.1

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] DCO signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
