### PR TITLE
Configure ingress paths from values.yaml

### DIFF
--- a/charts/litmus/Chart.yaml
+++ b/charts/litmus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.0.0"
 description: A Helm chart to install ChaosCenter
 name: litmus
-version: 2.0.29
+version: 2.0.30
 kubeVersion: ">=1.16.0-0"
 home: https://litmuschaos.io
 sources:

--- a/charts/litmus/README.md
+++ b/charts/litmus/README.md
@@ -1,6 +1,6 @@
 # litmus
 
-![Version: 2.0.29](https://img.shields.io/badge/Version-2.0.29-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 2.0.30](https://img.shields.io/badge/Version-2.0.30-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart to install ChaosCenter
 
@@ -46,7 +46,9 @@ $ helm install litmus-portal litmuschaos/litmus
 | image.imageRegistryName | string | `"litmuschaos"` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |
-| ingress.host | string | `""` |  |
+| ingress.host.name | string | `""` | This is ingress hostname (ex: my-domain.com) |
+| ingress.host.paths.backend | string | `"/backend/(.*)"` | You may need adapt the path depending your ingress-controller |
+| ingress.host.paths.frontend | string | `"/(.*)"` | You may need adapt the path depending your ingress-controller |
 | ingress.name | string | `"litmus-ingress"` |  |
 | ingress.tls | list | `[]` |  |
 | mongo.containerPort | int | `27017` |  |

--- a/charts/litmus/templates/ingress.yaml
+++ b/charts/litmus/templates/ingress.yaml
@@ -43,7 +43,7 @@ spec:
           service:
             name: litmusportal-frontend-service
             port:
-              number: 9001
+              number: 9091
       - path: {{ .Values.ingress.host.paths.backend }}
         pathType: ImplementationSpecific
         backend:
@@ -55,7 +55,7 @@ spec:
       - path: {{ .Values.ingress.host.paths.frontend }}
         backend:
           serviceName: litmusportal-frontend-service
-          servicePort: 9001
+          servicePort: 9091
       - path: {{ .Values.ingress.host.paths.backend }}
         backend: 
           serviceName: litmusportal-server-service

--- a/charts/litmus/templates/ingress.yaml
+++ b/charts/litmus/templates/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   {{- if .Values.ingress.tls }}
   tls:
-    {{- range.Values.tls }}
+    {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
         - {{ . | quote }}
@@ -29,37 +29,36 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-  {{- if .Values.ingress.host }}
-  - host: {{ .Values.ingress.host | quote }}
+  {{- if .Values.ingress.host.name }}
+  - host: {{ .Values.ingress.host.name | quote }}
     http:
   {{- else }}
   - http: 
   {{- end }}
-    {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
       paths:
-      - path: /(.*)
+    {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+      - path: {{ .Values.ingress.host.paths.frontend }}
         pathType: ImplementationSpecific
         backend:
           service:
             name: litmusportal-frontend-service
             port:
-              number: 9091
-      - path: /backend/(.*)
+              number: 9001
+      - path: {{ .Values.ingress.host.paths.backend }}
         pathType: ImplementationSpecific
         backend:
-          service:
+          service: 
             name: litmusportal-server-service
-            port:
+            port: 
               number: 9002
     {{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
-      paths:
-      - path: /(.*)
+      - path: {{ .Values.ingress.host.paths.frontend }}
         backend:
           serviceName: litmusportal-frontend-service
-          servicePort: 9091
-      - path: /backend/(.*)
-        backend:
+          servicePort: 9001
+      - path: {{ .Values.ingress.host.paths.backend }}
+        backend: 
           serviceName: litmusportal-server-service
           servicePort: 9002
     {{- end }}
-  {{- end }}
+{{- end }}

--- a/charts/litmus/values.yaml
+++ b/charts/litmus/values.yaml
@@ -33,7 +33,14 @@ ingress:
     # kubernetes.io/tls-acme: "true"
     # nginx.ingress.kubernetes.io/rewrite-target: /$1
 
-  host: ""
+  host:
+    # -- This is ingress hostname (ex: my-domain.com)
+    name: ""
+    paths:
+      # -- You may need adapt the path depending your ingress-controller
+      frontend: /(.*)
+      # -- You may need adapt the path depending your ingress-controller
+      backend: /backend/(.*)
   tls: []
   #  - secretName: chart-example-tls
   #    hosts: []


### PR DESCRIPTION
Signed-off-by: Rémi ZIOLKOWSKI <remi.ziolkowski-ext@pole-emploi.fr>

<!--

* https://github.com/helm/helm/tree/master/docs/chart_best_practices

Following best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This permit the user to configure path for the ingress depending of ingress controller ( kubernetes-nginx, ingress-nginx, traefik, etc... )
We need it cause the helm chart is un-usable without it


#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] DCO signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
