### PR TITLE
Change ImagePullPolicy & mongo readiness probe timeouts

### DIFF
--- a/charts/litmus/Chart.yaml
+++ b/charts/litmus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.0.0"
 description: A Helm chart to install ChaosCenter
 name: litmus
-version: 2.0.32
+version: 2.0.33
 kubeVersion: ">=1.16.0-0"
 home: https://litmuschaos.io
 sources:

--- a/charts/litmus/README.md
+++ b/charts/litmus/README.md
@@ -1,6 +1,6 @@
 # litmus
 
-![Version: 2.0.32](https://img.shields.io/badge/Version-2.0.32-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 2.0.33](https://img.shields.io/badge/Version-2.0.33-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart to install ChaosCenter
 
@@ -54,7 +54,7 @@ $ helm install litmus-portal litmuschaos/litmus
 | mongo.affinity | object | `{}` |  |
 | mongo.containerPort | int | `27017` |  |
 | mongo.customLabels | object | `{}` |  |
-| mongo.image.pullPolicy | string | `"Always"` |  |
+| mongo.image.pullPolicy | string | `"IfNotPresent"` |  |
 | mongo.image.repository | string | `"mongo"` |  |
 | mongo.image.tag | string | `"4.2.8"` |  |
 | mongo.livenessProbe.failureThreshold | int | `5` |  |
@@ -68,7 +68,7 @@ $ helm install litmus-portal litmuschaos/litmus
 | mongo.readinessProbe.initialDelaySeconds | int | `5` |  |
 | mongo.readinessProbe.periodSeconds | int | `10` |  |
 | mongo.readinessProbe.successThreshold | int | `1` |  |
-| mongo.readinessProbe.timeoutSeconds | int | `1` |  |
+| mongo.readinessProbe.timeoutSeconds | int | `2` |  |
 | mongo.replicas | int | `1` |  |
 | mongo.resources | object | `{}` |  |
 | mongo.service.port | int | `27017` |  |
@@ -83,7 +83,7 @@ $ helm install litmus-portal litmuschaos/litmus
 | portal.frontend.affinity | object | `{}` |  |
 | portal.frontend.containerPort | int | `8080` |  |
 | portal.frontend.customLabels | object | `{}` |  |
-| portal.frontend.image.pullPolicy | string | `"Always"` |  |
+| portal.frontend.image.pullPolicy | string | `"IfNotPresent"` |  |
 | portal.frontend.image.repository | string | `"litmusportal-frontend"` |  |
 | portal.frontend.image.tag | string | `"2.0.0"` |  |
 | portal.frontend.livenessProbe.failureThreshold | int | `5` |  |
@@ -110,7 +110,7 @@ $ helm install litmus-portal litmuschaos/litmus
 | portal.server.authServer.containerPort | int | `3000` |  |
 | portal.server.authServer.env.ADMIN_PASSWORD | string | `"litmus"` |  |
 | portal.server.authServer.env.ADMIN_USERNAME | string | `"admin"` |  |
-| portal.server.authServer.image.pullPolicy | string | `"Always"` |  |
+| portal.server.authServer.image.pullPolicy | string | `"IfNotPresent"` |  |
 | portal.server.authServer.image.repository | string | `"litmusportal-auth-server"` |  |
 | portal.server.authServer.image.tag | string | `"2.0.0"` |  |
 | portal.server.authServer.resources | object | `{}` |  |
@@ -122,7 +122,7 @@ $ helm install litmus-portal litmuschaos/litmus
 | portal.server.graphqlServer.genericEnv.PORTAL_ENDPOINT | string | `"http://litmusportal-server-service:9002"` |  |
 | portal.server.graphqlServer.genericEnv.SELF_CLUSTER | string | `"true"` |  |
 | portal.server.graphqlServer.genericEnv.SERVER_SERVICE_NAME | string | `"litmusportal-server-service"` |  |
-| portal.server.graphqlServer.image.pullPolicy | string | `"Always"` |  |
+| portal.server.graphqlServer.image.pullPolicy | string | `"IfNotPresent"` |  |
 | portal.server.graphqlServer.image.repository | string | `"litmusportal-server"` |  |
 | portal.server.graphqlServer.image.tag | string | `"2.0.0"` |  |
 | portal.server.graphqlServer.imageEnv.ARGO_WORKFLOW_CONTROLLER_IMAGE | string | `"workflow-controller:v2.11.0"` |  |
@@ -154,7 +154,7 @@ $ helm install litmus-portal litmuschaos/litmus
 | portal.server.updateStrategy | object | `{}` |  |
 | portalScope | string | `"cluster"` |  |
 | upgradeAgent.affinity | object | `{}` |  |
-| upgradeAgent.controlPlane.image.pullPolicy | string | `"Always"` |  |
+| upgradeAgent.controlPlane.image.pullPolicy | string | `"IfNotPresent"` |  |
 | upgradeAgent.controlPlane.image.repository | string | `"upgrade-agent-cp"` |  |
 | upgradeAgent.controlPlane.image.tag | string | `"ci"` |  |
 | upgradeAgent.nodeSelector | object | `{}` |  |

--- a/charts/litmus/README.md
+++ b/charts/litmus/README.md
@@ -95,7 +95,7 @@ $ helm install litmus-portal litmuschaos/litmus
 | portal.frontend.readinessProbe.initialDelaySeconds | int | `5` |  |
 | portal.frontend.readinessProbe.periodSeconds | int | `10` |  |
 | portal.frontend.readinessProbe.successThreshold | int | `1` |  |
-| portal.frontend.readinessProbe.timeoutSeconds | int | `1` |  |
+| portal.frontend.readinessProbe.timeoutSeconds | string | `nil` |  |
 | portal.frontend.replicas | int | `1` |  |
 | portal.frontend.resources | object | `{}` |  |
 | portal.frontend.service.port | int | `9091` |  |

--- a/charts/litmus/values.yaml
+++ b/charts/litmus/values.yaml
@@ -233,7 +233,7 @@ mongo:
     initialDelaySeconds: 5
     periodSeconds: 10
     successThreshold: 1
-    timeoutSeconds: 1
+    timeoutSeconds: 2
   persistence:
     size: 20Gi
     accessMode: ReadWriteOnce

--- a/charts/litmus/values.yaml
+++ b/charts/litmus/values.yaml
@@ -7,8 +7,9 @@ portalScope: cluster
 nameOverride: ""
 
 # -- Additional labels
-customLabels: {}
-  # my.company.com/concourse-cd: 2  
+customLabels:
+  {}
+  # my.company.com/concourse-cd: 2
 
 adminConfig:
   DBUSER: "admin"
@@ -50,7 +51,7 @@ upgradeAgent:
     image:
       repository: upgrade-agent-cp
       tag: "ci"
-      pullPolicy: "Always"
+      pullPolicy: "IfNotPresent"
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -71,7 +72,7 @@ portal:
     image:
       repository: litmusportal-frontend
       tag: 2.0.0
-      pullPolicy: "Always"
+      pullPolicy: "IfNotPresent"
     containerPort: 8080
     customLabels: {}
     # my.company.com/tier: "frontend"
@@ -130,7 +131,7 @@ portal:
       image:
         repository: litmusportal-server
         tag: 2.0.0
-        pullPolicy: "Always"
+        pullPolicy: "IfNotPresent"
       containerPort: 8080
       imageEnv:
         SUBSCRIBER_IMAGE: "litmusportal-subscriber:2.0.0"
@@ -146,7 +147,7 @@ portal:
         PORTAL_ENDPOINT: "http://litmusportal-server-service:9002"
         CONTAINER_RUNTIME_EXECUTOR: "k8sapi"
         HUB_BRANCH_NAME: "v2.0.x"
-        AGENT_DEPLOYMENTS: "[\"app=chaos-exporter\", \"name=chaos-operator\", \"app=event-tracker\", \"app=workflow-controller\"]"
+        AGENT_DEPLOYMENTS: '["app=chaos-exporter", "name=chaos-operator", "app=event-tracker", "app=workflow-controller"]'
       resources: {}
       # We usually recommend not to specify default resources and to leave this as a conscious
       # choice for the user. This also increases chances charts run on environments with little
@@ -173,7 +174,7 @@ portal:
       image:
         repository: litmusportal-auth-server
         tag: 2.0.0
-        pullPolicy: "Always"
+        pullPolicy: "IfNotPresent"
       containerPort: 3000
       env:
         ADMIN_USERNAME: "admin"
@@ -203,12 +204,13 @@ portal:
 
 mongo:
   replicas: 1
-  customLabels: {}
+  customLabels:
+    {}
     # my.company.com/tier: "database"
   image:
     repository: mongo
     tag: 4.2.8
-    pullPolicy: "Always"
+    pullPolicy: "IfNotPresent"
   containerPort: 27017
   resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION

#### What this PR does / why we need it:

Changes default Image policy to IfNotPresent to avoid Docker rate limit issues.
Increases timout for Mongo Readiness probe after discovering it was too low when deploying on our EKS clusters.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] DCO signed
- [x] Chart Version bumped

