### PR TITLE
Move Passwords to Kubernetes Secrets and Install Init Pod only when using local Mongo instance

### DIFF
--- a/charts/litmus/Chart.yaml
+++ b/charts/litmus/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "2.1.1"
+appVersion: "2.1.3"
 description: A Helm chart to install ChaosCenter
 name: litmus
 version: 2.1.3

--- a/charts/litmus/templates/admin-secrets.yaml
+++ b/charts/litmus/templates/admin-secrets.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "litmus-portal.fullname" . }}-admin-secrets
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "litmus-portal.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "litmus-portal.name" . }}-admin-secrets
+type: Opaque
+data:
+  DB_PASSWORD: {{ .Values.adminConfig.DBPASSWORD | b64enc | quote }}
+  JWTSecret: {{ .Values.adminConfig.JWTSecret | b64enc | quote }}

--- a/charts/litmus/templates/controlplane-configs.yaml
+++ b/charts/litmus/templates/controlplane-configs.yaml
@@ -9,11 +9,15 @@ metadata:
 data:
   AGENT_SCOPE: "{{ .Values.portalScope }}"
   AGENT_NAMESPACE: "{{ .Release.Namespace }}"
-  {{- if .Values.adminConfig.DB_SERVER }}
+  {{- if and (.Values.adminConfig.DB_SERVER)  (.Values.adminConfig.DBCONNECT_OPTIONS) }}
+  DB_SERVER: "mongodb://{{ .Values.adminConfig.DB_SERVER }}:{{ .Values.adminConfig.DB_PORT }}/{{ .Values.adminConfig.DBCONNECT_OPTIONS }}"
+  {{- else if .Values.adminConfig.DB_SERVER }}
   DB_SERVER: "mongodb://{{ .Values.adminConfig.DB_SERVER }}:{{ .Values.adminConfig.DB_PORT }}"
-  {{- else }}
+  {{- else if not .Values.adminConfig.DB_SERVER }}
   DB_SERVER: "mongodb://{{ include "litmus-portal.fullname" . }}-mongo:{{ .Values.adminConfig.DB_PORT }}"
   {{- end }}
+  JWT_SECRET: "{{ .Values.adminConfig.JWTSecret }}"
+  DB_USER: "{{ .Values.adminConfig.DBUSER }}"
   VERSION: "{{ .Values.adminConfig.VERSION }}"
 ---
 apiVersion: v1

--- a/charts/litmus/templates/controlplane-secrets.yaml
+++ b/charts/litmus/templates/controlplane-secrets.yaml
@@ -7,6 +7,5 @@ metadata:
     {{- include "litmus-portal.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "litmus-portal.name" . }}-admin-secret
 stringData:
-  JWT_SECRET: "litmus-portal@123"
-  DB_USER: "admin"
-  DB_PASSWORD: "1234"
+  DB_PASSWORD: {{ .Values.adminConfig.DBPASSWORD | quote }}
+  JWTSecret: {{ .Values.adminConfig.JWTSecret | quote }}

--- a/charts/litmus/templates/ingress.yaml
+++ b/charts/litmus/templates/ingress.yaml
@@ -41,14 +41,14 @@ spec:
         pathType: ImplementationSpecific
         backend:
           service:
-            name: litmusportal-frontend-service
+            name: {{ include "litmus-portal.fullname" . }}-frontend-service
             port:
               number: 9091
       - path: {{ .Values.ingress.host.paths.backend }}
         pathType: ImplementationSpecific
         backend:
           service: 
-            name: litmusportal-server-service
+            name: {{ include "litmus-portal.fullname" . }}-server-service
             port: 
               number: 9002
     {{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}

--- a/charts/litmus/templates/mongo-sts.yaml
+++ b/charts/litmus/templates/mongo-sts.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.adminConfig.DB_SERVER "" }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -98,3 +99,4 @@ spec:
         resources:
           requests:
             storage: {{ .Values.mongo.persistence.size }}
+{{- end }}

--- a/charts/litmus/templates/mongo-svc.yaml
+++ b/charts/litmus/templates/mongo-svc.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.adminConfig.DB_SERVER "" }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -15,3 +16,4 @@ spec:
       targetPort: {{ .Values.mongo.service.targetPort }}
   selector:
     app.kubernetes.io/component: {{ include "litmus-portal.name" . }}-database
+{{- end }}

--- a/charts/litmus/templates/server-deployment.yaml
+++ b/charts/litmus/templates/server-deployment.yaml
@@ -32,6 +32,7 @@ spec:
       imagePullSecrets:
         {{ toYaml .Values.image.imagePullSecrets | indent 8 }}
       {{- end }}
+      {{- if eq .Values.adminConfig.DB_SERVER "" }}
       initContainers:
         - name: wait-for-mongodb
           image: {{ .Values.image.imageRegistryName }}/{{ .Values.portal.server.waitForMongodb.image.repository }}:{{ .Values.portal.server.waitForMongodb.image.tag }}
@@ -41,6 +42,7 @@ spec:
             [
               "while [[ $(curl -sw '%{http_code}' http://{{ include "litmus-portal.fullname" . }}-mongo:{{ .Values.adminConfig.DB_PORT }} -o /dev/null) -ne 200 ]]; do sleep 5; echo 'Waiting for the MongoDB to be ready...'; done; echo 'Connection with MongoDB established'",
             ]
+      {{- end }}
       containers:
         - name: graphql-server
           image: {{ .Values.image.imageRegistryName }}/{{ .Values.portal.server.graphqlServer.image.repository }}:{{ .Values.portal.server.graphqlServer.image.tag }}
@@ -61,11 +63,16 @@ spec:
               port: graphql-server
             {{- toYaml .Values.portal.server.graphqlServer.readinessProbe | nindent 12 }}
           envFrom:
-            - secretRef:
-                name: {{ include "litmus-portal.fullname" . }}-admin-secret
-            - configMapRef:
-                name: {{ include "litmus-portal.fullname" . }}-admin-config
+          - secretRef:
+              name: {{ include "litmus-portal.fullname" . }}-admin-secret
+          - configMapRef:
+              name: {{ include "litmus-portal.fullname" . }}-admin-config
           env:
+            - name: DB_SERVER
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "litmus-portal.fullname" . }}-admin-config
+                  key: DB_SERVER
             - name: LITMUS_PORTAL_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -82,6 +89,26 @@ spec:
               value: "{{ .Values.ingress.enabled }}"
             - name: INGRESS_NAME
               value: "{{ .Values.ingress.name }}"
+            - name: AGENT_SCOPE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "litmus-portal.fullname" . }}-admin-config
+                  key: AGENT_SCOPE
+            - name: AGENT_NAMESPACE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "litmus-portal.fullname" . }}-admin-config
+                  key: AGENT_NAMESPACE
+            - name: DB_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "litmus-portal.fullname" . }}-admin-config
+                  key: DB_USER
+            - name: VERSION
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "litmus-portal.fullname" . }}-admin-config
+                  key: VERSION
             - name: NODE_NAME
               valueFrom:
                 fieldRef:
@@ -104,10 +131,10 @@ spec:
           resources:
             {{- toYaml .Values.portal.server.authServer.resources | nindent 12 }}
           envFrom:
-            - secretRef:
-                name: {{ include "litmus-portal.fullname" . }}-admin-secret
-            - configMapRef:
-                name: {{ include "litmus-portal.fullname" . }}-admin-config
+          - secretRef:
+              name: {{ include "litmus-portal.fullname" . }}-admin-secret
+          - configMapRef:
+              name: {{ include "litmus-portal.fullname" . }}-admin-config
           env:
             {{- range $key, $val := .Values.portal.server.authServer.env }}
             - name: {{ $key }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Today, we are populating MongoDB password, JWT via config maps. Config Maps of one pod can be easily viewed using Kubelet from node or other pods. This is not recommended method to populate sensitive information to pods. Hence, changed them to secrets.

#### Which issue this PR fixes
NA

#### Special notes for your reviewer:
NA

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] DCO signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
