### PR TITLE
fix(litmus): do not hardcode svc name in ingress

### DIFF
--- a/charts/litmus/Chart.yaml
+++ b/charts/litmus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.1.1"
 description: A Helm chart to install ChaosCenter
 name: litmus
-version: 2.1.4
+version: 2.1.5
 kubeVersion: ">=1.16.0-0"
 home: https://litmuschaos.io
 sources:

--- a/charts/litmus/Chart.yaml
+++ b/charts/litmus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.1.1"
 description: A Helm chart to install ChaosCenter
 name: litmus
-version: 2.1.3
+version: 2.1.4
 kubeVersion: ">=1.16.0-0"
 home: https://litmuschaos.io
 sources:

--- a/charts/litmus/README.md
+++ b/charts/litmus/README.md
@@ -1,6 +1,6 @@
 # litmus
 
-![Version: 2.1.4](https://img.shields.io/badge/Version-2.1.4-informational?style=flat-square) ![AppVersion: 2.1.1](https://img.shields.io/badge/AppVersion-2.1.1-informational?style=flat-square)
+![Version: 2.1.5](https://img.shields.io/badge/Version-2.1.5-informational?style=flat-square) ![AppVersion: 2.1.1](https://img.shields.io/badge/AppVersion-2.1.1-informational?style=flat-square)
 
 A Helm chart to install ChaosCenter
 

--- a/charts/litmus/README.md
+++ b/charts/litmus/README.md
@@ -1,6 +1,6 @@
 # litmus
 
-![Version: 2.1.3](https://img.shields.io/badge/Version-2.1.3-informational?style=flat-square) ![AppVersion: 2.1.1](https://img.shields.io/badge/AppVersion-2.1.1-informational?style=flat-square)
+![Version: 2.1.4](https://img.shields.io/badge/Version-2.1.4-informational?style=flat-square) ![AppVersion: 2.1.1](https://img.shields.io/badge/AppVersion-2.1.1-informational?style=flat-square)
 
 A Helm chart to install ChaosCenter
 

--- a/charts/litmus/templates/ingress.yaml
+++ b/charts/litmus/templates/ingress.yaml
@@ -41,24 +41,24 @@ spec:
         pathType: ImplementationSpecific
         backend:
           service:
-            name: litmusportal-frontend-service
+            name: {{ $fullName }}-frontend-service
             port:
               number: 9091
       - path: {{ .Values.ingress.host.paths.backend }}
         pathType: ImplementationSpecific
         backend:
           service: 
-            name: litmusportal-server-service
+            name: {{ $fullName }}-server-service
             port: 
               number: 9002
     {{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
       - path: {{ .Values.ingress.host.paths.frontend }}
         backend:
-          serviceName: litmusportal-frontend-service
+          serviceName: {{ $fullName }}-frontend-service
           servicePort: 9091
       - path: {{ .Values.ingress.host.paths.backend }}
         backend: 
-          serviceName: litmusportal-server-service
+          serviceName: {{ $fullName }}-server-service
           servicePort: 9002
     {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Tuan Anh Tran <me@tuananh.org>

#### What this PR does / why we need it:

the service is generated using `$fullname` but reference service name in ingress is hardcode.


#### Which issue this PR fixes

Fix #174


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] DCO signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
