### PR TITLE
support ingress class definition in spec

### DIFF
--- a/charts/litmus/Chart.yaml
+++ b/charts/litmus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.7.0"
 description: A Helm chart to install ChaosCenter
 name: litmus
-version: 2.7.1
+version: 2.7.2
 kubeVersion: ">=1.16.0-0"
 home: https://litmuschaos.io
 sources:

--- a/charts/litmus/README.md
+++ b/charts/litmus/README.md
@@ -52,6 +52,7 @@ $ helm install litmus-portal litmuschaos/litmus
 | ingress.host.name | string | `""` | This is ingress hostname (ex: my-domain.com) |
 | ingress.host.paths.backend | string | `"/backend/(.*)"` | You may need adapt the path depending your ingress-controller |
 | ingress.host.paths.frontend | string | `"/(.*)"` | You may need adapt the path depending your ingress-controller |
+| ingress.ingressClassName | string | `""` |  |
 | ingress.name | string | `"litmus-ingress"` |  |
 | ingress.tls | list | `[]` |  |
 | mongo.affinity | object | `{}` |  |

--- a/charts/litmus/README.md
+++ b/charts/litmus/README.md
@@ -1,6 +1,6 @@
 # litmus
 
-![Version: 2.7.1](https://img.shields.io/badge/Version-2.7.1-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
+![Version: 2.7.2](https://img.shields.io/badge/Version-2.7.2-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
 
 A Helm chart to install ChaosCenter
 

--- a/charts/litmus/templates/ingress.yaml
+++ b/charts/litmus/templates/ingress.yaml
@@ -18,6 +18,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}

--- a/charts/litmus/values.yaml
+++ b/charts/litmus/values.yaml
@@ -33,10 +33,10 @@ ingress:
   name: litmus-ingress
   annotations:
     {}
-    # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
     # nginx.ingress.kubernetes.io/rewrite-target: /$1
 
+  ingressClassName: ""
   host:
     # -- This is ingress hostname (ex: my-domain.com)
     name: ""


### PR DESCRIPTION
Signed-off-by: stoehdoi <domi.stoehr@googlemail.com>

#### What this PR does / why we need it:
Ingress class should be defined in the spec rather than in the annotations: https://kubernetes.io/docs/concepts/services-networking/ingress/#the-ingress-resource 

#### Special notes for your reviewer:
For some ingress controller implementations this could be a breaking change. For example, the admission controller of nginx IC does not allow specifying the ingress class in both directives, annotations and spec. Hence, making the `.spec.ingressClassName` conditional. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] DCO signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

cc: @rajdas98 @ispeakc0de @Jasstkn 
