### PR TITLE
Bypass front nginx by forwarding requests directly from ingress to api and ws 

### DIFF
--- a/charts/litmus/README.md
+++ b/charts/litmus/README.md
@@ -50,8 +50,11 @@ $ helm install litmus-portal litmuschaos/litmus
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |
 | ingress.host.name | string | `""` | This is ingress hostname (ex: my-domain.com) |
+| ingress.host.paths.api | string | `""` | *Optionnal* You may need to shunt nginx front to pass requests directly to api |
+| ingress.host.paths.auth | string | `""` | *Optionnal* You may need to shunt nginx front to pass requests directly to auth server  |
 | ingress.host.paths.backend | string | `"/backend/(.*)"` | You may need adapt the path depending your ingress-controller |
 | ingress.host.paths.frontend | string | `"/(.*)"` | You may need adapt the path depending your ingress-controller |
+| ingress.host.paths.ws | string | `""` | *Optionnal* You may need to shunt nginx front to pass requests directly to websocket |
 | ingress.ingressClassName | string | `""` |  |
 | ingress.name | string | `"litmus-ingress"` |  |
 | ingress.tls | list | `[]` |  |

--- a/charts/litmus/templates/ingress.yaml
+++ b/charts/litmus/templates/ingress.yaml
@@ -77,9 +77,9 @@ spec:
         pathType: ImplementationSpecific
         backend:
           service:
-            name: {{ $fullName }}-server-service
+            name: {{ include "litmus-portal.fullname" . }}-auth-server-service
             port:
-              number: 9002
+              number: 9003
       {{- end }}
     {{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
       - path: {{ .Values.ingress.host.paths.frontend }}
@@ -105,7 +105,7 @@ spec:
       {{- if .Values.ingress.host.paths.auth }}
       - path: {{ .Values.ingress.host.paths.auth }}
         backend:
-          serviceName: {{ $fullName }}-server-service
+          serviceName: {{ include "litmus-portal.fullname" . }}-auth-server-service
           servicePort: 9003
       {{- end }}
     {{- end }}

--- a/charts/litmus/templates/ingress.yaml
+++ b/charts/litmus/templates/ingress.yaml
@@ -54,6 +54,33 @@ spec:
             name: {{ $fullName }}-server-service
             port: 
               number: 9002
+      {{- if .Values.ingress.host.paths.api }}
+      - path: {{ .Values.ingress.host.paths.api }}
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: {{ $fullName }}-server-service
+            port:
+              number: 9002
+      {{- end }}
+      {{- if .Values.ingress.host.paths.ws }}
+      - path: {{ .Values.ingress.host.paths.ws }}
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: {{ $fullName }}-server-service
+            port:
+              number: 9002
+      {{- end }}
+      {{- if .Values.ingress.host.paths.auth }}
+      - path: {{ .Values.ingress.host.paths.auth }}
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: {{ $fullName }}-server-service
+            port:
+              number: 9002
+      {{- end }}
     {{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
       - path: {{ .Values.ingress.host.paths.frontend }}
         backend:
@@ -63,5 +90,23 @@ spec:
         backend: 
           serviceName: {{ $fullName }}-server-service
           servicePort: 9002
+      {{- if .Values.ingress.host.paths.api }}
+      - path: {{ .Values.ingress.host.paths.api }}
+        backend:
+          serviceName: {{ $fullName }}-server-service
+          servicePort: 9002
+      {{- end }}
+      {{- if .Values.ingress.host.paths.ws }}
+      - path: {{ .Values.ingress.host.paths.ws }}
+        backend:
+          serviceName: {{ $fullName }}-server-service
+          servicePort: 9002
+      {{- end }}
+      {{- if .Values.ingress.host.paths.auth }}
+      - path: {{ .Values.ingress.host.paths.auth }}
+        backend:
+          serviceName: {{ $fullName }}-server-service
+          servicePort: 9003
+      {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/litmus/values.yaml
+++ b/charts/litmus/values.yaml
@@ -45,6 +45,15 @@ ingress:
       frontend: /(.*)
       # -- You may need adapt the path depending your ingress-controller
       backend: /backend/(.*)
+      # -- *Optionnal* You may need to shunt nginx front to pass requests directly to api
+      api: ""
+      # /api/(.*)
+      # -- *Optionnal* You may need to shunt nginx front to pass requests directly to websocket
+      ws: ""
+      # /ws/(.*)
+      # -- *Optionnal* You may need to shunt nginx front to pass requests directly to auth server 
+      auth: ""
+      # /auth/(.*)
   tls: []
   #  - secretName: chart-example-tls
   #    hosts: []


### PR DESCRIPTION
<!--

* https://github.com/helm/helm/tree/master/docs/chart_best_practices

Following best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
-    adding possibility to shunt front to directly pass requests from ingress to api
-    adding possibility to shunt front to directly pass requests from ingress to ws
-    adding possibility to shunt front to directly pass requests from ingress to auth

We need it to fasten calls to our services

#### Special notes for your reviewer:
replacement for https://github.com/litmuschaos/litmus-helm/pull/226 which was made on the wrong branch

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] DCO signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
