### PR TITLE
Updated helmchart for supporting prefixPath in virtual-service and envoy proxy(Istio)

### DIFF
--- a/charts/litmus/Chart.yaml
+++ b/charts/litmus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.9.0"
 description: A Helm chart to install ChaosCenter
 name: litmus
-version: 2.9.0
+version: 2.9.1
 kubeVersion: ">=1.16.0-0"
 home: https://litmuschaos.io
 sources:

--- a/charts/litmus/README.md
+++ b/charts/litmus/README.md
@@ -1,6 +1,6 @@
 # litmus
 
-![Version: 2.9.0](https://img.shields.io/badge/Version-2.9.0-informational?style=flat-square) ![AppVersion: 2.9.0](https://img.shields.io/badge/AppVersion-2.9.0-informational?style=flat-square)
+![Version: 2.9.1](https://img.shields.io/badge/Version-2.9.1-informational?style=flat-square) ![AppVersion: 2.9.0](https://img.shields.io/badge/AppVersion-2.9.0-informational?style=flat-square)
 
 A Helm chart to install ChaosCenter
 
@@ -127,6 +127,7 @@ $ helm install litmus-portal litmuschaos/litmus
 | portal.frontend.virtualService.enabled | bool | `false` |  |
 | portal.frontend.virtualService.gateways | list | `[]` |  |
 | portal.frontend.virtualService.hosts | list | `[]` |  |
+| portal.frontend.virtualService.pathPrefixEnabled | bool | `false` |  |
 | portal.server.affinity | object | `{}` |  |
 | portal.server.authServer.automountServiceAccountToken | bool | `false` |  |
 | portal.server.authServer.env.LITMUS_GQL_GRPC_PORT | string | `":8000"` |  |

--- a/charts/litmus/templates/controlplane-configs.yaml
+++ b/charts/litmus/templates/controlplane-configs.yaml
@@ -27,12 +27,17 @@ metadata:
     app.kubernetes.io/component: {{ include "litmus-portal.name" . }}-admin-config
 data:
   default.conf: |
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
+    }
     server {
         listen       8080;
         server_name  localhost;
         #charset koi8-r;
         #access_log  /var/log/nginx/host.access.log  main;
         location / {
+            proxy_http_version 1.1;
             root   /usr/share/nginx/html;
             index  index.html index.htm;
             try_files $uri /index.html;
@@ -51,6 +56,7 @@ data:
         #    deny  all;
         #}
         location /auth/ {
+            proxy_http_version 1.1;
             proxy_set_header   Host                 $host;
             proxy_set_header   X-Real-IP            $remote_addr;
             proxy_set_header   X-Forwarded-For      $proxy_add_x_forwarded_for;
@@ -58,6 +64,7 @@ data:
             proxy_pass "http://{{ include "litmus-portal.fullname" . }}-auth-server-service:9003/";
         }
         location /api/ {
+            proxy_http_version 1.1;
             proxy_set_header   Host                 $host;
             proxy_set_header   X-Real-IP            $remote_addr;
             proxy_set_header   X-Forwarded-For      $proxy_add_x_forwarded_for;
@@ -65,8 +72,9 @@ data:
             proxy_pass "http://{{ include "litmus-portal.fullname" . }}-server-service:9002/";
         }
         location /ws/ {
-            proxy_set_header   Upgrade              $http_upgrade;
-            proxy_set_header   Connection           "Upgrade";
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
             proxy_set_header   Host                 $host;
             proxy_set_header   X-Real-IP            $remote_addr;
             proxy_set_header   X-Forwarded-For      $proxy_add_x_forwarded_for;

--- a/charts/litmus/templates/frontend-vs.yaml
+++ b/charts/litmus/templates/frontend-vs.yaml
@@ -18,9 +18,18 @@ spec:
     {{- toYaml . | nindent 4 }}
 {{- end }}
   http:
-    - route:
-      - destination:
-          host: litmusportal-frontend-service
-          port:
-            number: {{ .Values.portal.frontend.service.port }}
+{{- if .Values.portal.frontend.virtualService.pathPrefixEnabled }}
+  - match:
+    - uri:
+        prefix: /litmuschaos
+    rewrite:
+      uri: "/"
+    route:
+{{- else }}
+  - route:
+{{- end }}
+    - destination:
+        host:  {{ include "litmus-portal.fullname" . }}-frontend-service
+        port:
+          number: {{ .Values.portal.frontend.service.port }}
 {{- end -}}

--- a/charts/litmus/templates/ingress.yaml
+++ b/charts/litmus/templates/ingress.yaml
@@ -10,6 +10,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ .Values.ingress.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: {{ include "litmus-portal.name" . }}-frontend
     {{- include "litmus-portal.labels" . | nindent 4 }}

--- a/charts/litmus/values.yaml
+++ b/charts/litmus/values.yaml
@@ -34,7 +34,7 @@ ingress:
   annotations:
     {}
     # kubernetes.io/tls-acme: "true"
-  # nginx.ingress.kubernetes.io/rewrite-target: /$1
+    # nginx.ingress.kubernetes.io/rewrite-target: /$1
 
   ingressClassName: ""
   host:
@@ -86,11 +86,11 @@ portal:
     customLabels: {}
     # my.company.com/tier: "frontend"
 
-    resources:
-      # We usually recommend not to specify default resources and to leave this as a conscious
-      # choice for the user. This also increases chances charts run on environments with little
-      # resources, such as Minikube. If you do want to specify resources, uncomment the following
-      # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    resources: 
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
       requests:
         memory: "150Mi"
         cpu: "125m"
@@ -119,6 +119,7 @@ portal:
       enabled: false
       hosts: []
       gateways: []
+      pathPrefixEnabled: false
     nodeSelector: {}
     tolerations: []
     affinity: {}


### PR DESCRIPTION
Signed-off-by: Vedant Shrotria <vedant.shrotria@harness.io>

<!--

* https://github.com/helm/helm/tree/master/docs/chart_best_practices

Following best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

**This PR will -** 
- Add support for prefix in virtual-service for istio
- Fixes the hardcoded name of frontend-service in virtual-service
- Fixes namespace in Ingress
- Adds Support for envoy proxy through frontend-nginx-config.

**Above changes have been tested with Ingress as well as Virtual service, both are working fine with `/` & `/litmuschaos` paths.** 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] DCO signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
