### PR TITLE
Chore(2.9.0): Update helm docs for version 2.9.0 

### DIFF
--- a/charts/kube-aws/Chart.yaml
+++ b/charts/kube-aws/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "2.9.0"
+appVersion: "2.10.0"
 description: A Helm chart to install litmus aws chaos experiments
 name: kube-aws
-version: 2.9.1
+version: 2.10.0
 home: https://litmuschaos.io
 sources:
   - https://github.com/litmuschaos/litmus

--- a/charts/kube-aws/README.md
+++ b/charts/kube-aws/README.md
@@ -1,6 +1,6 @@
 # kube-aws
 
-![Version: 2.9.1](https://img.shields.io/badge/Version-2.9.1-informational?style=flat-square) ![AppVersion: 2.9.0](https://img.shields.io/badge/AppVersion-2.9.0-informational?style=flat-square)
+![Version: 2.10.0](https://img.shields.io/badge/Version-2.10.0-informational?style=flat-square) ![AppVersion: 2.10.0](https://img.shields.io/badge/AppVersion-2.10.0-informational?style=flat-square)
 
 A Helm chart to install litmus aws chaos experiments
 
@@ -27,7 +27,7 @@ A Helm chart to install litmus aws chaos experiments
 | fullnameOverride | string | `"kube-aws"` |  |
 | image.litmusGO.pullPolicy | string | `"Always"` |  |
 | image.litmusGO.repository | string | `"litmuschaos/go-runner"` |  |
-| image.litmusGO.tag | string | `"2.9.0"` |  |
+| image.litmusGO.tag | string | `"2.10.0"` |  |
 | nameOverride | string | `"kube-aws"` |  |
 
 ----------------------------------------------

--- a/charts/kube-aws/values.yaml
+++ b/charts/kube-aws/values.yaml
@@ -11,7 +11,7 @@ customLabels: {}
 image:
   litmusGO:
     repository: litmuschaos/go-runner
-    tag: 2.9.0
+    tag: 2.10.0
     pullPolicy: Always
 
 experiments:

--- a/charts/kube-azure/Chart.yaml
+++ b/charts/kube-azure/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "2.9.0"
+appVersion: "2.10.0"
 description: A Helm chart to install litmus Azure chaos experiments
 name: kube-azure
-version: 2.9.1
+version: 2.10.0
 home: https://litmuschaos.io
 sources:
   - https://github.com/litmuschaos/litmus

--- a/charts/kube-azure/README.md
+++ b/charts/kube-azure/README.md
@@ -1,6 +1,6 @@
 # kube-azure
 
-![Version: 2.9.1](https://img.shields.io/badge/Version-2.9.1-informational?style=flat-square) ![AppVersion: 2.9.0](https://img.shields.io/badge/AppVersion-2.9.0-informational?style=flat-square)
+![Version: 2.10.0](https://img.shields.io/badge/Version-2.10.0-informational?style=flat-square) ![AppVersion: 2.10.0](https://img.shields.io/badge/AppVersion-2.10.0-informational?style=flat-square)
 
 A Helm chart to install litmus Azure chaos experiments
 
@@ -27,7 +27,7 @@ A Helm chart to install litmus Azure chaos experiments
 | fullnameOverride | string | `"kube-azure"` |  |
 | image.litmusGO.pullPolicy | string | `"Always"` |  |
 | image.litmusGO.repository | string | `"litmuschaos/go-runner"` |  |
-| image.litmusGO.tag | string | `"2.9.0"` |  |
+| image.litmusGO.tag | string | `"2.10.0"` |  |
 | nameOverride | string | `"kube-azure"` |  |
 
 ----------------------------------------------

--- a/charts/kube-azure/values.yaml
+++ b/charts/kube-azure/values.yaml
@@ -11,7 +11,7 @@ customLabels: {}
 image:
   litmusGO:
     repository: litmuschaos/go-runner
-    tag: 2.9.0
+    tag: 2.10.0
     pullPolicy: Always
 
 experiments:

--- a/charts/kube-gcp/Chart.yaml
+++ b/charts/kube-gcp/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "2.9.0"
+appVersion: "2.10.0"
 description: A Helm chart to install litmus gcp chaos experiments
 name: kube-gcp
-version: 2.9.1
+version: 2.10.0
 home: https://litmuschaos.io
 sources:
   - https://github.com/litmuschaos/litmus

--- a/charts/kube-gcp/README.md
+++ b/charts/kube-gcp/README.md
@@ -1,6 +1,6 @@
 # kube-gcp
 
-![Version: 2.9.1](https://img.shields.io/badge/Version-2.9.1-informational?style=flat-square) ![AppVersion: 2.9.0](https://img.shields.io/badge/AppVersion-2.9.0-informational?style=flat-square)
+![Version: 2.10.0](https://img.shields.io/badge/Version-2.10.0-informational?style=flat-square) ![AppVersion: 2.10.0](https://img.shields.io/badge/AppVersion-2.10.0-informational?style=flat-square)
 
 A Helm chart to install litmus gcp chaos experiments
 
@@ -27,7 +27,7 @@ A Helm chart to install litmus gcp chaos experiments
 | fullnameOverride | string | `"kube-gcp"` |  |
 | image.litmusGO.pullPolicy | string | `"Always"` |  |
 | image.litmusGO.repository | string | `"litmuschaos/go-runner"` |  |
-| image.litmusGO.tag | string | `"2.9.0"` |  |
+| image.litmusGO.tag | string | `"2.10.0"` |  |
 | nameOverride | string | `"kube-gcp"` |  |
 
 ----------------------------------------------

--- a/charts/kube-gcp/values.yaml
+++ b/charts/kube-gcp/values.yaml
@@ -11,7 +11,7 @@ customLabels: {}
 image:
   litmusGO:
     repository: litmuschaos/go-runner
-    tag: 2.9.0
+    tag: 2.10.0
     pullPolicy: Always
 
 experiments:

--- a/charts/kubernetes-chaos/Chart.yaml
+++ b/charts/kubernetes-chaos/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "2.9.0"
+appVersion: "2.10.0"
 description: A Helm chart to install litmus chaos experiments for kubernetes category (chaos-chart)
 name: kubernetes-chaos
 version: 2.23.1

--- a/charts/kubernetes-chaos/Chart.yaml
+++ b/charts/kubernetes-chaos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.10.0"
 description: A Helm chart to install litmus chaos experiments for kubernetes category (chaos-chart)
 name: kubernetes-chaos
-version: 2.23.1
+version: 2.24.0
 home: https://litmuschaos.io
 sources:
   - https://github.com/litmuschaos/litmus

--- a/charts/kubernetes-chaos/README.md
+++ b/charts/kubernetes-chaos/README.md
@@ -1,6 +1,6 @@
 # kubernetes-chaos
 
-![Version: 2.23.1](https://img.shields.io/badge/Version-2.23.1-informational?style=flat-square) ![AppVersion: 2.10.0](https://img.shields.io/badge/AppVersion-2.10.0-informational?style=flat-square)
+![Version: 2.24.0](https://img.shields.io/badge/Version-2.24.0-informational?style=flat-square) ![AppVersion: 2.10.0](https://img.shields.io/badge/AppVersion-2.10.0-informational?style=flat-square)
 
 A Helm chart to install litmus chaos experiments for kubernetes category (chaos-chart)
 

--- a/charts/kubernetes-chaos/README.md
+++ b/charts/kubernetes-chaos/README.md
@@ -1,6 +1,6 @@
 # kubernetes-chaos
 
-![Version: 2.23.1](https://img.shields.io/badge/Version-2.23.1-informational?style=flat-square) ![AppVersion: 2.9.0](https://img.shields.io/badge/AppVersion-2.9.0-informational?style=flat-square)
+![Version: 2.23.1](https://img.shields.io/badge/Version-2.23.1-informational?style=flat-square) ![AppVersion: 2.10.0](https://img.shields.io/badge/AppVersion-2.10.0-informational?style=flat-square)
 
 A Helm chart to install litmus chaos experiments for kubernetes category (chaos-chart)
 
@@ -30,12 +30,12 @@ A Helm chart to install litmus chaos experiments for kubernetes category (chaos-
 | fullnameOverride | string | `"k8s"` |  |
 | image.litmus.pullPolicy | string | `"Always"` |  |
 | image.litmus.repository | string | `"litmuschaos/ansible-runner"` |  |
-| image.litmus.tag | string | `"2.8.0"` |  |
+| image.litmus.tag | string | `"2.10.0"` |  |
 | image.litmusGO.pullPolicy | string | `"Always"` |  |
 | image.litmusGO.repository | string | `"litmuschaos/go-runner"` |  |
-| image.litmusGO.tag | string | `"2.8.0"` |  |
+| image.litmusGO.tag | string | `"2.10.0"` |  |
 | image.litmusLIBImage.repository | string | `"litmuschaos/go-runner"` |  |
-| image.litmusLIBImage.tag | string | `"2.8.0"` |  |
+| image.litmusLIBImage.tag | string | `"2.10.0"` |  |
 | image.networkChaos.tcImage | string | `"gaiadocker/iproute2"` |  |
 | image.pumba.libName | string | `"pumba"` |  |
 | image.resourceChaos.respository | string | `"alexeiled/stress-ng"` |  |

--- a/charts/kubernetes-chaos/values.yaml
+++ b/charts/kubernetes-chaos/values.yaml
@@ -11,12 +11,12 @@ customLabels: {}
 image:
   litmus:
     repository: litmuschaos/ansible-runner
-    tag: 2.8.0
+    tag: 2.10.0
     pullPolicy: Always
 
   litmusGO:
     repository: litmuschaos/go-runner
-    tag: 2.8.0
+    tag: 2.10.0
     pullPolicy: Always
 
   pumba:
@@ -24,7 +24,7 @@ image:
 
   litmusLIBImage:
     repository: litmuschaos/go-runner
-    tag: 2.8.0
+    tag: 2.10.0
 
   networkChaos:
     tcImage: gaiadocker/iproute2

--- a/charts/litmus-core/Chart.yaml
+++ b/charts/litmus-core/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "2.9.0"
+appVersion: "2.10.0"
 description: A Helm chart to install litmus infra components on Kubernetes
 name: litmus-core
-version: 2.9.1
+version: 2.10.0
 home: https://litmuschaos.io
 sources:
   - https://github.com/litmuschaos/litmus

--- a/charts/litmus-core/README.md
+++ b/charts/litmus-core/README.md
@@ -1,6 +1,6 @@
 # litmus-core
 
-![Version: 2.9.1](https://img.shields.io/badge/Version-2.9.1-informational?style=flat-square) ![AppVersion: 2.9.0](https://img.shields.io/badge/AppVersion-2.9.0-informational?style=flat-square)
+![Version: 2.10.0](https://img.shields.io/badge/Version-2.10.0-informational?style=flat-square) ![AppVersion: 2.10.0](https://img.shields.io/badge/AppVersion-2.10.0-informational?style=flat-square)
 
 A Helm chart to install litmus infra components on Kubernetes
 
@@ -27,7 +27,7 @@ A Helm chart to install litmus infra components on Kubernetes
 | exporter.enabled | bool | `false` |  |
 | exporter.image.pullPolicy | string | `"Always"` |  |
 | exporter.image.repository | string | `"litmuschaos/chaos-exporter"` |  |
-| exporter.image.tag | string | `"2.9.0"` |  |
+| exporter.image.tag | string | `"2.10.0"` |  |
 | exporter.nodeSelector | object | `{}` |  |
 | exporter.priorityClassName | string | `nil` |  |
 | exporter.resources | object | `{}` |  |
@@ -47,7 +47,7 @@ A Helm chart to install litmus infra components on Kubernetes
 | nodeSelector | object | `{}` |  |
 | operator.image.pullPolicy | string | `"Always"` |  |
 | operator.image.repository | string | `"litmuschaos/chaos-operator"` |  |
-| operator.image.tag | string | `"2.9.0"` |  |
+| operator.image.tag | string | `"2.10.0"` |  |
 | operatorMode | string | `"standard"` |  |
 | operatorName | string | `"chaos-operator"` |  |
 | policies.monitoring.disabled | bool | `false` |  |
@@ -57,7 +57,7 @@ A Helm chart to install litmus infra components on Kubernetes
 | resources.requests.cpu | string | `"100m"` |  |
 | resources.requests.memory | string | `"128Mi"` |  |
 | runner.image.repository | string | `"litmuschaos/chaos-runner"` |  |
-| runner.image.tag | string | `"2.9.0"` |  |
+| runner.image.tag | string | `"2.10.0"` |  |
 | service.port | int | `80` |  |
 | service.type | string | `"ClusterIP"` |  |
 | tolerations | list | `[]` |  |

--- a/charts/litmus-core/values.yaml
+++ b/charts/litmus-core/values.yaml
@@ -15,12 +15,12 @@ replicaCount: 1
 operator:
   image:
     repository: litmuschaos/chaos-operator
-    tag: 2.9.0
+    tag: 2.10.0
     pullPolicy: Always
 runner:
   image:
     repository: litmuschaos/chaos-runner
-    tag: 2.9.0
+    tag: 2.10.0
 
 service:
   type: ClusterIP
@@ -75,7 +75,7 @@ exporter:
     additionalLabels: {}
   image:
     repository: litmuschaos/chaos-exporter
-    tag: 2.9.0
+    tag: 2.10.0
     pullPolicy: Always
   service:
     type: ClusterIP


### PR DESCRIPTION
Signed-off-by: Akash Shrivastava <akash.shrivastava@harness.io>

#### What this PR does / why we need it:
This PR updates the Helm charts for the v2.10.0 release

#### Special notes for your reviewer:
`kubernetes-chaos/values.yaml` chart was not updated in the last release PR. Have bumped it to 2.10.0 from 2.8.0

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] DCO signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
