### PR TITLE
Chore(http-chaos): Add Charts for the new http chaos experiments 

### DIFF
--- a/charts/kubernetes-chaos/Chart.yaml
+++ b/charts/kubernetes-chaos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.10.0"
 description: A Helm chart to install litmus chaos experiments for kubernetes category (chaos-chart)
 name: kubernetes-chaos
-version: 2.24.1
+version: 2.24.2
 home: https://litmuschaos.io
 sources:
   - https://github.com/litmuschaos/litmus

--- a/charts/kubernetes-chaos/README.md
+++ b/charts/kubernetes-chaos/README.md
@@ -1,6 +1,6 @@
 # kubernetes-chaos
 
-![Version: 2.24.1](https://img.shields.io/badge/Version-2.24.1-informational?style=flat-square) ![AppVersion: 2.10.0](https://img.shields.io/badge/AppVersion-2.10.0-informational?style=flat-square)
+![Version: 2.24.2](https://img.shields.io/badge/Version-2.24.2-informational?style=flat-square) ![AppVersion: 2.10.0](https://img.shields.io/badge/AppVersion-2.10.0-informational?style=flat-square)
 
 A Helm chart to install litmus chaos experiments for kubernetes category (chaos-chart)
 

--- a/charts/kubernetes-chaos/README.md
+++ b/charts/kubernetes-chaos/README.md
@@ -1,7 +1,6 @@
 # kubernetes-chaos
 
-
-![Version: 2.25.1](https://img.shields.io/badge/Version-2.25.0-informational?style=flat-square) ![AppVersion: 2.11.0](https://img.shields.io/badge/AppVersion-2.11.0-informational?style=flat-square)
+![Version: 2.25.1](https://img.shields.io/badge/Version-2.25.1-informational?style=flat-square) ![AppVersion: 2.11.0](https://img.shields.io/badge/AppVersion-2.11.0-informational?style=flat-square)
 
 A Helm chart to install litmus chaos experiments for kubernetes category (chaos-chart)
 

--- a/charts/kubernetes-chaos/templates/pod-http-latency.yaml
+++ b/charts/kubernetes-chaos/templates/pod-http-latency.yaml
@@ -1,0 +1,130 @@
+{{ if not (has "pod-http-latency" .Values.experiments.disabled) }}
+apiVersion: litmuschaos.io/v1alpha1
+description:
+  message: |
+    Injects http request latency on pods belonging to an app deployment
+kind: ChaosExperiment
+metadata:
+  name: pod-http-latency
+  labels:
+    {{- include "kubernetes-chaos.labels" . | indent 4 }}
+spec:
+  definition:
+    scope: Namespaced
+    permissions:
+      # Create and monitor the experiment & helper pods
+      - apiGroups: [""]
+        resources: ["pods"]
+        verbs: ["create","delete","get","list","patch","update", "deletecollection"]
+      # Performs CRUD operations on the events inside chaosengine and chaosresult
+      - apiGroups: [""]
+        resources: ["events"]
+        verbs: ["create","get","list","patch","update"]
+      # Fetch configmaps details and mount it to the experiment pod (if specified)
+      - apiGroups: [""]
+        resources: ["configmaps"]
+        verbs: ["get","list",]
+      # Track and get the runner, experiment, and helper pods log 
+      - apiGroups: [""]
+        resources: ["pods/log"]
+        verbs: ["get","list","watch"]  
+      # for creating and managing to execute comands inside target container
+      - apiGroups: [""]
+        resources: ["pods/exec"]
+        verbs: ["get","list","create"]
+      # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+      - apiGroups: ["apps"]
+        resources: ["deployments","statefulsets","replicasets", "daemonsets"]
+        verbs: ["list","get"]
+      # deriving the parent/owner details of the pod(if parent is deploymentConfig)  
+      - apiGroups: ["apps.openshift.io"]
+        resources: ["deploymentconfigs"]
+        verbs: ["list","get"]
+      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+      - apiGroups: [""]
+        resources: ["replicationcontrollers"]
+        verbs: ["get","list"]
+      # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+      - apiGroups: ["argoproj.io"]
+        resources: ["rollouts"]
+        verbs: ["list","get"]
+      # for configuring and monitor the experiment job by the chaos-runner pod
+      - apiGroups: ["batch"]
+        resources: ["jobs"]
+        verbs: ["create","list","get","delete","deletecollection"]
+      # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+      - apiGroups: ["litmuschaos.io"]
+        resources: ["chaosengines","chaosexperiments","chaosresults"]
+        verbs: ["create","list","get","patch","update","delete"]
+    image: "{{ .Values.image.litmusGO.repository }}:{{ .Values.image.litmusGO.tag }}"
+    imagePullPolicy: {{ .Values.image.litmusGO.pullPolicy }}
+    args:
+    - -c
+    - ./experiments -name pod-http-latency
+    command:
+    - /bin/bash
+    env:
+    
+    - name: TARGET_CONTAINER
+      value: ''
+
+    # provide lib image
+    - name: LIB_IMAGE
+      value: "{{ .Values.image.litmusLIBImage.repository }}:{{ .Values.image.litmusLIBImage.tag }}"
+
+    - name: LATENCY
+      value: '2000' #in ms
+
+    # port of the target service
+    - name: TARGET_SERVICE_PORT
+      value: "80"
+
+    # port on which the proxy will listen
+    - name: PROXY_PORT
+      value: "20000"
+    
+    # network interface on which the proxy will listen
+    - name: NETWORK_INTERFACE
+      value: "eth0"
+
+    - name: TOTAL_CHAOS_DURATION
+      value: '60' # in seconds
+
+    # Time period to wait before and after injection of chaos in sec
+    - name: RAMP_TIME
+      value: ''
+
+    # lib can be litmus or pumba
+    - name: LIB
+      value: 'litmus'
+
+    # percentage of total pods to target
+    - name: PODS_AFFECTED_PERC
+      value: ''
+
+    - name: TARGET_PODS
+      value: ''
+
+    # provide the name of container runtime
+    # for litmus LIB, it supports docker, containerd, crio
+    # for pumba LIB, it supports docker only
+    - name: CONTAINER_RUNTIME
+      value: 'docker'
+
+    # provide the socket file path
+    - name: SOCKET_PATH
+      value: '/var/run/docker.sock'
+
+    # To select pods on specific node(s)
+    - name: NODE_LABEL
+      value: ''
+
+    ## it defines the sequence of chaos execution for multiple target pods
+    ## supported values: serial, parallel
+    - name: SEQUENCE
+      value: 'parallel'
+
+    labels:
+      name: pod-http-latency
+      app.kubernetes.io/part-of: litmus
+{{ end }}

--- a/charts/kubernetes-chaos/templates/pod-http-modify-body.yaml
+++ b/charts/kubernetes-chaos/templates/pod-http-modify-body.yaml
@@ -1,0 +1,132 @@
+{{ if not (has "pod-http-modify-body" .Values.experiments.disabled) }}
+apiVersion: litmuschaos.io/v1alpha1
+description:
+  message: |
+    It injects the chaos inside the pod which modifies the body of the response from the provided application server to the body string provided by the user and reverts after a specified duration
+kind: ChaosExperiment
+metadata:
+  name: pod-http-modify-body
+  labels:
+    {{- include "kubernetes-chaos.labels" . | indent 4 }}
+spec:
+  definition:
+    scope: Namespaced
+    permissions:
+      # Create and monitor the experiment & helper pods
+      - apiGroups: [""]
+        resources: ["pods"]
+        verbs: ["create","delete","get","list","patch","update", "deletecollection"]
+      # Performs CRUD operations on the events inside chaosengine and chaosresult
+      - apiGroups: [""]
+        resources: ["events"]
+        verbs: ["create","get","list","patch","update"]
+      # Fetch configmaps details and mount it to the experiment pod (if specified)
+      - apiGroups: [""]
+        resources: ["configmaps"]
+        verbs: ["get","list",]
+      # Track and get the runner, experiment, and helper pods log 
+      - apiGroups: [""]
+        resources: ["pods/log"]
+        verbs: ["get","list","watch"]  
+      # for creating and managing to execute comands inside target container
+      - apiGroups: [""]
+        resources: ["pods/exec"]
+        verbs: ["get","list","create"]
+      # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+      - apiGroups: ["apps"]
+        resources: ["deployments","statefulsets","replicasets", "daemonsets"]
+        verbs: ["list","get"]
+      # deriving the parent/owner details of the pod(if parent is deploymentConfig)  
+      - apiGroups: ["apps.openshift.io"]
+        resources: ["deploymentconfigs"]
+        verbs: ["list","get"]
+      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+      - apiGroups: [""]
+        resources: ["replicationcontrollers"]
+        verbs: ["get","list"]
+      # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+      - apiGroups: ["argoproj.io"]
+        resources: ["rollouts"]
+        verbs: ["list","get"]
+      # for configuring and monitor the experiment job by the chaos-runner pod
+      - apiGroups: ["batch"]
+        resources: ["jobs"]
+        verbs: ["create","list","get","delete","deletecollection"]
+      # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+      - apiGroups: ["litmuschaos.io"]
+        resources: ["chaosengines","chaosexperiments","chaosresults"]
+        verbs: ["create","list","get","patch","update","delete"]
+    image: "{{ .Values.image.litmusGO.repository }}:{{ .Values.image.litmusGO.tag }}"
+    imagePullPolicy: {{ .Values.image.litmusGO.pullPolicy }}
+    args:
+    - -c
+    - ./experiments -name pod-http-modify-body
+    command:
+    - /bin/bash
+    env:
+
+    - name: TARGET_CONTAINER
+      value: ''
+
+    # provide lib image
+    - name: LIB_IMAGE
+      value: "{{ .Values.image.litmusLIBImage.repository }}:{{ .Values.image.litmusLIBImage.tag }}"
+    
+    # provide the body string to overwrite the response body
+    # if no value is provided, response will be an empty body.
+    - name: RESPONSE_BODY
+      value: ''
+
+    # port of the target service
+    - name: TARGET_SERVICE_PORT
+      value: "80"
+
+    # port on which the proxy will listen
+    - name: PROXY_PORT
+      value: "20000"
+    
+    # network interface on which the proxy will listen
+    - name: NETWORK_INTERFACE
+      value: "eth0"
+
+    - name: TOTAL_CHAOS_DURATION
+      value: '60' # in seconds
+
+    # Time period to wait before and after injection of chaos in sec
+    - name: RAMP_TIME
+      value: ''
+
+    # lib can be litmus or pumba
+    - name: LIB
+      value: 'litmus'
+
+    # percentage of total pods to target
+    - name: PODS_AFFECTED_PERC
+      value: ''
+
+    - name: TARGET_PODS
+      value: ''
+
+    # provide the name of container runtime
+    # for litmus LIB, it supports docker, containerd, crio
+    # for pumba LIB, it supports docker only
+    - name: CONTAINER_RUNTIME
+      value: 'docker'
+
+    # provide the socket file path
+    - name: SOCKET_PATH
+      value: '/var/run/docker.sock'
+
+    # To select pods on specific node(s)
+    - name: NODE_LABEL
+      value: ''
+
+    ## it defines the sequence of chaos execution for multiple target pods
+    ## supported values: serial, parallel
+    - name: SEQUENCE
+      value: 'parallel'
+      
+    labels:
+      name: pod-http-modify-body
+      app.kubernetes.io/part-of: litmus
+{{ end }}

--- a/charts/kubernetes-chaos/templates/pod-http-modify-header.yaml
+++ b/charts/kubernetes-chaos/templates/pod-http-modify-header.yaml
@@ -1,0 +1,136 @@
+{{ if not (has "pod-http-modify-header" .Values.experiments.disabled) }}
+apiVersion: litmuschaos.io/v1alpha1
+description:
+  message: |
+    It injects the chaos inside the pod which modifies the header of the request/response from the provided application server to the headers provided by the user and reverts after a specified duration
+kind: ChaosExperiment
+metadata:
+  name: pod-http-modify-header
+  labels:
+    {{- include "kubernetes-chaos.labels" . | indent 4 }}
+spec:
+  definition:
+    scope: Namespaced
+    permissions:
+      # Create and monitor the experiment & helper pods
+      - apiGroups: [""]
+        resources: ["pods"]
+        verbs: ["create","delete","get","list","patch","update", "deletecollection"]
+      # Performs CRUD operations on the events inside chaosengine and chaosresult
+      - apiGroups: [""]
+        resources: ["events"]
+        verbs: ["create","get","list","patch","update"]
+      # Fetch configmaps details and mount it to the experiment pod (if specified)
+      - apiGroups: [""]
+        resources: ["configmaps"]
+        verbs: ["get","list",]
+      # Track and get the runner, experiment, and helper pods log 
+      - apiGroups: [""]
+        resources: ["pods/log"]
+        verbs: ["get","list","watch"]  
+      # for creating and managing to execute comands inside target container
+      - apiGroups: [""]
+        resources: ["pods/exec"]
+        verbs: ["get","list","create"]
+      # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+      - apiGroups: ["apps"]
+        resources: ["deployments","statefulsets","replicasets", "daemonsets"]
+        verbs: ["list","get"]
+      # deriving the parent/owner details of the pod(if parent is deploymentConfig)  
+      - apiGroups: ["apps.openshift.io"]
+        resources: ["deploymentconfigs"]
+        verbs: ["list","get"]
+      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+      - apiGroups: [""]
+        resources: ["replicationcontrollers"]
+        verbs: ["get","list"]
+      # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+      - apiGroups: ["argoproj.io"]
+        resources: ["rollouts"]
+        verbs: ["list","get"]
+      # for configuring and monitor the experiment job by the chaos-runner pod
+      - apiGroups: ["batch"]
+        resources: ["jobs"]
+        verbs: ["create","list","get","delete","deletecollection"]
+      # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+      - apiGroups: ["litmuschaos.io"]
+        resources: ["chaosengines","chaosexperiments","chaosresults"]
+        verbs: ["create","list","get","patch","update","delete"]
+    image: "{{ .Values.image.litmusGO.repository }}:{{ .Values.image.litmusGO.tag }}"
+    imagePullPolicy: {{ .Values.image.litmusGO.pullPolicy }}
+    args:
+    - -c
+    - ./experiments -name pod-http-modify-header
+    command:
+    - /bin/bash
+    env:
+    
+    - name: TARGET_CONTAINER
+      value: ''
+
+    # provide lib image
+    - name: LIB_IMAGE
+      value: "{{ .Values.image.litmusLIBImage.repository }}:{{ .Values.image.litmusLIBImage.tag }}"
+
+    # map of headers to modify/add; Eg: {"X-Litmus-Test-Header": "X-Litmus-Test-Value"}
+    # to remove a header, just set the value to ""; Eg: {"X-Litmus-Test-Header": ""}
+    - name: HEADERS_MAP
+      value: '{}'
+
+    # whether to modify response headers or request headers. Accepted values: request, response
+    - name: HEADER_MODE
+      value: 'response'
+
+    # port of the target service
+    - name: TARGET_SERVICE_PORT
+      value: "80"
+
+    # port on which the proxy will listen
+    - name: PROXY_PORT
+      value: "20000"
+    
+    # network interface on which the proxy will listen
+    - name: NETWORK_INTERFACE
+      value: "eth0"
+
+    - name: TOTAL_CHAOS_DURATION
+      value: '60' # in seconds
+
+    # Time period to wait before and after injection of chaos in sec
+    - name: RAMP_TIME
+      value: ''
+
+    # lib can be litmus or pumba
+    - name: LIB
+      value: 'litmus'
+
+    # percentage of total pods to target
+    - name: PODS_AFFECTED_PERC
+      value: ''
+
+    - name: TARGET_PODS
+      value: ''
+
+    # provide the name of container runtime
+    # for litmus LIB, it supports docker, containerd, crio
+    # for pumba LIB, it supports docker only
+    - name: CONTAINER_RUNTIME
+      value: 'docker'
+
+    # provide the socket file path
+    - name: SOCKET_PATH
+      value: '/var/run/docker.sock'
+
+    # To select pods on specific node(s)
+    - name: NODE_LABEL
+      value: ''
+
+    ## it defines the sequence of chaos execution for multiple target pods
+    ## supported values: serial, parallel
+    - name: SEQUENCE
+      value: 'parallel'
+
+    labels:
+      name: pod-http-modify-header
+      app.kubernetes.io/part-of: litmus
+{{ end }}

--- a/charts/kubernetes-chaos/templates/pod-http-reset-peer.yaml
+++ b/charts/kubernetes-chaos/templates/pod-http-reset-peer.yaml
@@ -1,0 +1,131 @@
+{{ if not (has "pod-http-reset-peer" .Values.experiments.disabled) }}
+apiVersion: litmuschaos.io/v1alpha1
+description:
+  message: |
+    it injects chaos into the pod which stops outgoing http requests by resetting the TCP connection and then reverts back to the original state after a specified duration
+kind: ChaosExperiment
+metadata:
+  name: pod-http-reset-peer
+  labels:
+    {{- include "kubernetes-chaos.labels" . | indent 4 }}
+spec:
+  definition:
+    scope: Namespaced
+    permissions:
+      # Create and monitor the experiment & helper pods
+      - apiGroups: [""]
+        resources: ["pods"]
+        verbs: ["create","delete","get","list","patch","update", "deletecollection"]
+      # Performs CRUD operations on the events inside chaosengine and chaosresult
+      - apiGroups: [""]
+        resources: ["events"]
+        verbs: ["create","get","list","patch","update"]
+      # Fetch configmaps details and mount it to the experiment pod (if specified)
+      - apiGroups: [""]
+        resources: ["configmaps"]
+        verbs: ["get","list",]
+      # Track and get the runner, experiment, and helper pods log 
+      - apiGroups: [""]
+        resources: ["pods/log"]
+        verbs: ["get","list","watch"]  
+      # for creating and managing to execute comands inside target container
+      - apiGroups: [""]
+        resources: ["pods/exec"]
+        verbs: ["get","list","create"]
+      # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+      - apiGroups: ["apps"]
+        resources: ["deployments","statefulsets","replicasets", "daemonsets"]
+        verbs: ["list","get"]
+      # deriving the parent/owner details of the pod(if parent is deploymentConfig)  
+      - apiGroups: ["apps.openshift.io"]
+        resources: ["deploymentconfigs"]
+        verbs: ["list","get"]
+      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+      - apiGroups: [""]
+        resources: ["replicationcontrollers"]
+        verbs: ["get","list"]
+      # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+      - apiGroups: ["argoproj.io"]
+        resources: ["rollouts"]
+        verbs: ["list","get"]
+      # for configuring and monitor the experiment job by the chaos-runner pod
+      - apiGroups: ["batch"]
+        resources: ["jobs"]
+        verbs: ["create","list","get","delete","deletecollection"]
+      # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+      - apiGroups: ["litmuschaos.io"]
+        resources: ["chaosengines","chaosexperiments","chaosresults"]
+        verbs: ["create","list","get","patch","update","delete"]
+    image: "{{ .Values.image.litmusGO.repository }}:{{ .Values.image.litmusGO.tag }}"
+    imagePullPolicy: {{ .Values.image.litmusGO.pullPolicy }}
+    args:
+    - -c
+    - ./experiments -name pod-http-reset-peer
+    command:
+    - /bin/bash
+    env:
+
+    - name: TARGET_CONTAINER
+      value: ''
+
+    # provide lib image
+    - name: LIB_IMAGE
+      value: "{{ .Values.image.litmusLIBImage.repository }}:{{ .Values.image.litmusLIBImage.tag }}"
+    
+    # reset timeout specifies after how much duration to reset the connection
+    - name: RESET_TIMEOUT
+      value: '0' #in ms
+
+    # port of the target service
+    - name: TARGET_SERVICE_PORT
+      value: "80"
+
+    # port on which the proxy will listen
+    - name: PROXY_PORT
+      value: "20000"
+    
+    # network interface on which the proxy will listen
+    - name: NETWORK_INTERFACE
+      value: "eth0"
+
+    - name: TOTAL_CHAOS_DURATION
+      value: '60' # in seconds
+
+    # Time period to wait before and after injection of chaos in sec
+    - name: RAMP_TIME
+      value: ''
+
+    # lib can be litmus or pumba
+    - name: LIB
+      value: 'litmus'
+
+    # percentage of total pods to target
+    - name: PODS_AFFECTED_PERC
+      value: ''
+
+    - name: TARGET_PODS
+      value: ''
+
+    # provide the name of container runtime
+    # for litmus LIB, it supports docker, containerd, crio
+    # for pumba LIB, it supports docker only
+    - name: CONTAINER_RUNTIME
+      value: 'docker'
+
+    # provide the socket file path
+    - name: SOCKET_PATH
+      value: '/var/run/docker.sock'
+
+    # To select pods on specific node(s)
+    - name: NODE_LABEL
+      value: ''
+
+    ## it defines the sequence of chaos execution for multiple target pods
+    ## supported values: serial, parallel
+    - name: SEQUENCE
+      value: 'parallel'
+      
+    labels:
+      name: pod-http-reset-peer
+      app.kubernetes.io/part-of: litmus
+{{ end }}

--- a/charts/kubernetes-chaos/templates/pod-http-status-code.yaml
+++ b/charts/kubernetes-chaos/templates/pod-http-status-code.yaml
@@ -1,0 +1,138 @@
+{{ if not (has "pod-http-status-code" .Values.experiments.disabled) }}
+apiVersion: litmuschaos.io/v1alpha1
+description:
+  message: |
+    It injects chaos inside the pod which modifies the status code of the response from the provided application server to desired status code provided by the user and reverts after a specified duration
+kind: ChaosExperiment
+metadata:
+  name: pod-http-status-code
+  labels:
+    {{- include "kubernetes-chaos.labels" . | indent 4 }}
+spec:
+  definition:
+    scope: Namespaced
+    permissions:
+      # Create and monitor the experiment & helper pods
+      - apiGroups: [""]
+        resources: ["pods"]
+        verbs: ["create","delete","get","list","patch","update", "deletecollection"]
+      # Performs CRUD operations on the events inside chaosengine and chaosresult
+      - apiGroups: [""]
+        resources: ["events"]
+        verbs: ["create","get","list","patch","update"]
+      # Fetch configmaps details and mount it to the experiment pod (if specified)
+      - apiGroups: [""]
+        resources: ["configmaps"]
+        verbs: ["get","list",]
+      # Track and get the runner, experiment, and helper pods log 
+      - apiGroups: [""]
+        resources: ["pods/log"]
+        verbs: ["get","list","watch"]  
+      # for creating and managing to execute comands inside target container
+      - apiGroups: [""]
+        resources: ["pods/exec"]
+        verbs: ["get","list","create"]
+      # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+      - apiGroups: ["apps"]
+        resources: ["deployments","statefulsets","replicasets", "daemonsets"]
+        verbs: ["list","get"]
+      # deriving the parent/owner details of the pod(if parent is deploymentConfig)  
+      - apiGroups: ["apps.openshift.io"]
+        resources: ["deploymentconfigs"]
+        verbs: ["list","get"]
+      # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+      - apiGroups: [""]
+        resources: ["replicationcontrollers"]
+        verbs: ["get","list"]
+      # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+      - apiGroups: ["argoproj.io"]
+        resources: ["rollouts"]
+        verbs: ["list","get"]
+      # for configuring and monitor the experiment job by the chaos-runner pod
+      - apiGroups: ["batch"]
+        resources: ["jobs"]
+        verbs: ["create","list","get","delete","deletecollection"]
+      # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+      - apiGroups: ["litmuschaos.io"]
+        resources: ["chaosengines","chaosexperiments","chaosresults"]
+        verbs: ["create","list","get","patch","update","delete"]
+    image: "{{ .Values.image.litmusGO.repository }}:{{ .Values.image.litmusGO.tag }}"
+    imagePullPolicy: {{ .Values.image.litmusGO.pullPolicy }}
+    args:
+    - -c
+    - ./experiments -name pod-http-status-code
+    command:
+    - /bin/bash
+    env:
+
+    - name: TARGET_CONTAINER
+      value: ''
+
+    # provide lib image
+    - name: LIB_IMAGE
+      value: "{{ .Values.image.litmusLIBImage.repository }}:{{ .Values.image.litmusLIBImage.tag }}"
+
+    # modified status code for the http response
+    # if no value is provided, a random status code from the supported code list will selected
+    # if an invalid status code is provided, the experiment will fail
+    # supported status code list: [200, 201, 202, 204, 300, 301, 302, 304, 307, 400, 401, 403, 404, 500, 501, 502, 503, 504]
+    - name: STATUS_CODE
+      value: ''
+
+    #  whether to modify the body as per the status code provided
+    - name: "MODIFY_RESPONSE_BODY"
+      value: "true"
+
+    # port of the target service
+    - name: TARGET_SERVICE_PORT
+      value: "80"
+
+    # port on which the proxy will listen
+    - name: PROXY_PORT
+      value: "20000"
+    
+    # network interface on which the proxy will listen
+    - name: NETWORK_INTERFACE
+      value: "eth0"
+
+    - name: TOTAL_CHAOS_DURATION
+      value: '60' # in seconds
+
+    # Time period to wait before and after injection of chaos in sec
+    - name: RAMP_TIME
+      value: ''
+
+    # lib can be litmus or pumba
+    - name: LIB
+      value: 'litmus'
+
+    # percentage of total pods to target
+    - name: PODS_AFFECTED_PERC
+      value: ''
+
+    - name: TARGET_PODS
+      value: ''
+
+    # provide the name of container runtime
+    # for litmus LIB, it supports docker, containerd, crio
+    # for pumba LIB, it supports docker only
+    - name: CONTAINER_RUNTIME
+      value: 'docker'
+
+    # provide the socket file path
+    - name: SOCKET_PATH
+      value: '/var/run/docker.sock'
+
+    # To select pods on specific node(s)
+    - name: NODE_LABEL
+      value: ''
+
+    ## it defines the sequence of chaos execution for multiple target pods
+    ## supported values: serial, parallel
+    - name: SEQUENCE
+      value: 'parallel'
+      
+    labels:
+      name: pod-http-status-code
+      app.kubernetes.io/part-of: litmus
+{{ end }}


### PR DESCRIPTION
#### What this PR does / why we need it:


- This PR adds HTTP Chaos Experiment Charts to helm - This will allow to install the experiment CR using helm. The experiments are:

- pod-http-modify-body
- pod-http-modify-header
- pod-http-reset-peer
- pod-http-response-code
- pod-http-network-latency

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] DCO signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
