### PR TITLE
Fix added upgradeAgent resources limits/requests to template

### DIFF
--- a/charts/litmus/Chart.yaml
+++ b/charts/litmus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2.11.0"
 description: A Helm chart to install ChaosCenter
 name: litmus
-version: 2.12.0
+version: 2.13.0
 kubeVersion: ">=1.16.0-0"
 home: https://litmuschaos.io
 sources:

--- a/charts/litmus/Chart.yaml
+++ b/charts/litmus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2.11.0"
 description: A Helm chart to install ChaosCenter
 name: litmus
-version: 2.13.0
+version: 2.12.1
 kubeVersion: ">=1.16.0-0"
 home: https://litmuschaos.io
 sources:

--- a/charts/litmus/README.md
+++ b/charts/litmus/README.md
@@ -1,6 +1,6 @@
 # litmus
 
-![Version: 2.13.0](https://img.shields.io/badge/Version-2.13.0-informational?style=flat-square) ![AppVersion: 2.11.0](https://img.shields.io/badge/AppVersion-2.11.0-informational?style=flat-square)
+![Version: 2.12.1](https://img.shields.io/badge/Version-2.12.1-informational?style=flat-square) ![AppVersion: 2.11.0](https://img.shields.io/badge/AppVersion-2.11.0-informational?style=flat-square)
 
 A Helm chart to install ChaosCenter
 

--- a/charts/litmus/README.md
+++ b/charts/litmus/README.md
@@ -1,6 +1,6 @@
 # litmus
 
-![Version: 2.12.0](https://img.shields.io/badge/Version-2.12.0-informational?style=flat-square) ![AppVersion: 2.11.0](https://img.shields.io/badge/AppVersion-2.11.0-informational?style=flat-square)
+![Version: 2.13.0](https://img.shields.io/badge/Version-2.13.0-informational?style=flat-square) ![AppVersion: 2.11.0](https://img.shields.io/badge/AppVersion-2.11.0-informational?style=flat-square)
 
 A Helm chart to install ChaosCenter
 
@@ -210,6 +210,7 @@ $ helm install litmus-portal litmuschaos/litmus
 | upgradeAgent.controlPlane.image.tag | string | `"2.11.0"` |  |
 | upgradeAgent.controlPlane.restartPolicy | string | `"OnFailure"` |  |
 | upgradeAgent.nodeSelector | object | `{}` |  |
+| upgradeAgent.resources | object | `{}` |  |
 | upgradeAgent.tolerations | list | `[]` |  |
 
 ----------------------------------------------

--- a/charts/litmus/templates/post-upgrade-hook.yaml
+++ b/charts/litmus/templates/post-upgrade-hook.yaml
@@ -58,6 +58,8 @@ spec:
                   name: {{ include "litmus-portal.secretname" . }}
                   key: DB_USER
               {{- end }}
+          resources:
+            {{- toYaml .Values.upgradeAgent.resources | nindent 12 }}
     {{- with .Values.upgradeAgent.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/litmus/values.yaml
+++ b/charts/litmus/values.yaml
@@ -62,6 +62,19 @@ upgradeAgent:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+
 
 portal:
   frontend:


### PR DESCRIPTION
<!--

* https://github.com/helm/helm/tree/master/docs/chart_best_practices

Following best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Fix added upgradeAgent resources limits/requests to template

#### Which issue this PR fixes
on our clusters we're forced to, (and it is considered as best-practice to), have resources limits/requests on all of our workloads. Not having them on upgrade agent makes it fail to start and therefore makes us impossible to upgrade litmus with this chart

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] DCO signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
