### PR TITLE
Allow users to set custom mongodb connection URIs

### DIFF
--- a/charts/litmus/Chart.yaml
+++ b/charts/litmus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2.12.0"
 description: A Helm chart to install ChaosCenter
 name: litmus
-version: 2.13.0
+version: 2.14.0
 kubeVersion: ">=1.16.0-0"
 home: https://litmuschaos.io
 sources:

--- a/charts/litmus/README.md
+++ b/charts/litmus/README.md
@@ -1,6 +1,6 @@
 # litmus
 
-![Version: 2.13.0](https://img.shields.io/badge/Version-2.13.0-informational?style=flat-square) ![AppVersion: 2.12.0](https://img.shields.io/badge/AppVersion-2.12.0-informational?style=flat-square)
+![Version: 2.14.0](https://img.shields.io/badge/Version-2.14.0-informational?style=flat-square) ![AppVersion: 2.12.0](https://img.shields.io/badge/AppVersion-2.12.0-informational?style=flat-square)
 
 A Helm chart to install ChaosCenter
 

--- a/charts/litmus/README.md
+++ b/charts/litmus/README.md
@@ -195,6 +195,7 @@ $ helm install litmus-portal litmuschaos/litmus
 | portal.server.serviceAccountName | string | `"litmus-server-account"` |  |
 | portal.server.tolerations | list | `[]` |  |
 | portal.server.updateStrategy | object | `{}` |  |
+| portal.server.waitForMongodb.enabled | bool | `true` |  |
 | portal.server.waitForMongodb.image.pullPolicy | string | `"Always"` |  |
 | portal.server.waitForMongodb.image.repository | string | `"curl"` |  |
 | portal.server.waitForMongodb.image.tag | string | `"2.11.0"` |  |

--- a/charts/litmus/templates/_helpers.tpl
+++ b/charts/litmus/templates/_helpers.tpl
@@ -79,9 +79,26 @@ Check for existing secret
 {{- end -}}
 
 {{- define "litmus-portal.mongodbServiceName" -}}
+    {{- if .Values.mongodb.enabled }}
     {{- if not (eq .Values.mongodb.architecture "replicaset") }}
         {{- include "mongodb.fullname" .Subcharts.mongodb -}}
     {{ else }}
         {{- include "mongodb.service.nameOverride" .Subcharts.mongodb -}}
     {{- end -}}
+    {{- end -}}
+{{- end -}}
+
+{{/*
+Check to see if the user has provided a MongoDB connection URI
+*/}}
+{{- define "litmus-portal.mongodbConnectionURI" -}}
+{{- if .Values.adminConfig.DB_SERVER }}
+{{- if contains "://" .Values.adminConfig.DB_SERVER }}
+{{- .Values.adminConfig.DB_SERVER -}}
+{{- else }}
+{{- printf "mongodb://%s:%s" .Values.adminConfig.DB_SERVER .Values.adminConfig.DB_PORT -}}
+{{- end }}
+{{- else }}
+{{- printf "mongodb://%s:%s" include "litmus-portal.mongodbServiceName" . .Values.mongodb.service.ports.mongodb -}}
+{{- end }}
 {{- end -}}

--- a/charts/litmus/templates/auth-server-deployment.yaml
+++ b/charts/litmus/templates/auth-server-deployment.yaml
@@ -33,6 +33,7 @@ spec:
       imagePullSecrets:
         {{ toYaml .Values.image.imagePullSecrets | indent 8 }}
       {{- end }}
+      {{- if and (.Values.portal.server.waitForMongodb.enabled) (.Values.mongodb.enabled) }}
       initContainers:
         - name: wait-for-mongodb
           image: {{ .Values.image.imageRegistryName }}/{{ .Values.portal.server.waitForMongodb.image.repository }}:{{ .Values.portal.server.waitForMongodb.image.tag }}
@@ -44,6 +45,7 @@ spec:
             ]
           resources:
             {{- toYaml .Values.portal.server.waitForMongodb.resources | nindent 12 }}
+      {{- end }}
       containers:
         - name: auth-server
           image: {{ .Values.image.imageRegistryName }}/{{ .Values.portal.server.authServer.image.repository }}:{{ .Values.portal.server.authServer.image.tag }}

--- a/charts/litmus/templates/controlplane-configs.yaml
+++ b/charts/litmus/templates/controlplane-configs.yaml
@@ -9,11 +9,7 @@ metadata:
 data:
   AGENT_SCOPE: "{{ .Values.portalScope }}"
   AGENT_NAMESPACE: "{{ .Release.Namespace }}"
-  {{- if .Values.adminConfig.DB_SERVER }}
-  DB_SERVER: "mongodb://{{ .Values.adminConfig.DB_SERVER }}:{{ .Values.adminConfig.DB_PORT }}"
-  {{- else }}
-  DB_SERVER: "mongodb://{{ include "litmus-portal.mongodbServiceName" . }}:{{ .Values.mongodb.service.ports.mongodb }}"
-  {{- end }}
+  DB_SERVER: {{ include "litmus-portal.mongodbConnectionURI" . }}
   VERSION: "{{ .Values.adminConfig.VERSION }}"
   SKIP_SSL_VERIFY: "{{ .Values.adminConfig.SKIP_SSL_VERIFY }}"
 ---

--- a/charts/litmus/templates/server-deployment.yaml
+++ b/charts/litmus/templates/server-deployment.yaml
@@ -34,6 +34,7 @@ spec:
       {{- end }}
       volumes:
         {{- toYaml .Values.portal.server.graphqlServer.volumes | default "" | nindent 8 }}
+      {{- if and (.Values.portal.server.waitForMongodb.enabled) (.Values.mongodb.enabled) }}
       initContainers:
         - name: wait-for-mongodb
           image: {{ .Values.image.imageRegistryName }}/{{ .Values.portal.server.waitForMongodb.image.repository }}:{{ .Values.portal.server.waitForMongodb.image.tag }}
@@ -45,6 +46,7 @@ spec:
             ]
           resources:
             {{- toYaml .Values.portal.server.waitForMongodb.resources | nindent 12 }}
+      {{- end }}
       containers:
         - name: graphql-server
           image: {{ .Values.image.imageRegistryName }}/{{ .Values.portal.server.graphqlServer.image.repository }}:{{ .Values.portal.server.graphqlServer.image.tag }}

--- a/charts/litmus/values.yaml
+++ b/charts/litmus/values.yaml
@@ -156,6 +156,7 @@ portal:
     customLabels: {}
     # my.company.com/tier: "backend"
     waitForMongodb:
+      enabled: true
       image:
         repository: curl
         tag: 2.11.0


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR allows more flexibility in configuring an external MongoDB instance. For example, MongoDB can be configured with a seed list via SRV records e.g. `mongodb+srv://cluster0.example.mongodb.net`. 

There is an initalization container that waits for MongoDB to become available. However, we should allow this initialization container to be enabled/disabled. This is handy when using an external MongoDB instance that we know is running.

I tested this PR with the MongoDB free hosted tier. When configuring the external MongoDB instance, I set `mongodb.enabled` to false and set `portal.server.waitForMongodb.enabled` to false.


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] DCO signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
