### PR TITLE
Allow customLabels for the exporter deployment

### DIFF
--- a/charts/litmus-core/Chart.yaml
+++ b/charts/litmus-core/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "2.13.0"
+appVersion: "2.13.1"
 description: A Helm chart to install litmus infra components on Kubernetes
 name: litmus-core
-version: 2.13.0
+version: 2.13.1
 home: https://litmuschaos.io
 sources:
   - https://github.com/litmuschaos/litmus

--- a/charts/litmus-core/README.md
+++ b/charts/litmus-core/README.md
@@ -1,6 +1,6 @@
 # litmus-core
 
-![Version: 2.13.0](https://img.shields.io/badge/Version-2.13.0-informational?style=flat-square) ![AppVersion: 2.13.0](https://img.shields.io/badge/AppVersion-2.13.0-informational?style=flat-square)
+![Version: 2.13.1](https://img.shields.io/badge/Version-2.13.1-informational?style=flat-square) ![AppVersion: 2.13.1](https://img.shields.io/badge/AppVersion-2.13.1-informational?style=flat-square)
 
 A Helm chart to install litmus infra components on Kubernetes
 
@@ -24,6 +24,7 @@ A Helm chart to install litmus infra components on Kubernetes
 | affinity | object | `{}` |  |
 | customLabels | object | `{}` | Additional labels |
 | exporter.affinity | object | `{}` |  |
+| exporter.customLabels | object | `{}` |  |
 | exporter.enabled | bool | `false` |  |
 | exporter.image.pullPolicy | string | `"Always"` |  |
 | exporter.image.repository | string | `"litmuschaos/chaos-exporter"` |  |

--- a/charts/litmus-core/templates/_helpers.tpl
+++ b/charts/litmus-core/templates/_helpers.tpl
@@ -41,8 +41,9 @@ app.kubernetes.io/part-of: {{ template "litmus.name" . }}
 app.kubernetes.io/version: "{{ .Chart.Version }}"
 helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }} 
 litmuschaos.io/version: {{ .Chart.AppVersion }}
-{{- if .Values.customLabels }}
 {{ toYaml .Values.customLabels }}
+{{- if and (.Values.exporter.customLabels) (eq .deployment "exporter") }}
+{{ toYaml .Values.exporter.customLabels }}
 {{- end }}
 {{- end }}
 

--- a/charts/litmus-core/templates/exporter-deployment.yaml
+++ b/charts/litmus-core/templates/exporter-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace:  {{ .Release.Namespace }}
   labels:
     app: {{ template "litmus.name" . }}
-    {{- include "litmus.labels" . | indent 4 }}
+    {{- include "litmus.labels" (merge (dict "deployment" "exporter") . ) | indent 4 }}
 spec:
   replicas: 1
   selector:
@@ -17,7 +17,7 @@ spec:
     metadata:
       labels:
         app: {{ template "litmus.name" . }}
-        {{- include "litmus.labels" . | indent 8 }}
+        {{- include "litmus.labels" (merge (dict "deployment" "exporter") . ) | indent 8 }}
     spec:
       serviceAccountName: {{ include "litmus.fullname" . }}
       serviceAccount: {{ include "litmus.fullname" . }}
@@ -25,7 +25,7 @@ spec:
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}
       containers:
-        - name: exporter
+        - name: litmus-exporter
           image: "{{ .Values.exporter.image.repository }}:{{ .Values.exporter.image.tag }}"
           imagePullPolicy: {{ .Values.exporter.image.pullPolicy }}
           env: 

--- a/charts/litmus-core/values.yaml
+++ b/charts/litmus-core/values.yaml
@@ -82,6 +82,8 @@ exporter:
     port: 8080
     annotations: {}
 
+  customLabels: {}
+
   resources: {}
 
   nodeSelector: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR is to allow custom labels to be set on the `exporter` deployment. The reason you might want to add custom labels on the exporter vs exporter/operator is to instruct a scraper to scrape the metrics endpoint. The current custom labels set the label on both the operator and exporter deployment.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] DCO signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
