### PR TITLE
Allow custom annotations to be set on the exporter deployment

### DIFF
--- a/charts/litmus-core/Chart.yaml
+++ b/charts/litmus-core/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.13.0"
 description: A Helm chart to install litmus infra components on Kubernetes
 name: litmus-core
-version: 2.13.0
+version: 2.13.1
 home: https://litmuschaos.io
 sources:
   - https://github.com/litmuschaos/litmus

--- a/charts/litmus-core/README.md
+++ b/charts/litmus-core/README.md
@@ -1,6 +1,6 @@
 # litmus-core
 
-![Version: 2.13.0](https://img.shields.io/badge/Version-2.13.0-informational?style=flat-square) ![AppVersion: 2.13.0](https://img.shields.io/badge/AppVersion-2.13.0-informational?style=flat-square)
+![Version: 2.13.1](https://img.shields.io/badge/Version-2.13.1-informational?style=flat-square) ![AppVersion: 2.13.0](https://img.shields.io/badge/AppVersion-2.13.0-informational?style=flat-square)
 
 A Helm chart to install litmus infra components on Kubernetes
 
@@ -24,6 +24,7 @@ A Helm chart to install litmus infra components on Kubernetes
 | affinity | object | `{}` |  |
 | customLabels | object | `{}` | Additional labels |
 | exporter.affinity | object | `{}` |  |
+| exporter.annotations | object | `{}` | |
 | exporter.enabled | bool | `false` |  |
 | exporter.image.pullPolicy | string | `"Always"` |  |
 | exporter.image.repository | string | `"litmuschaos/chaos-exporter"` |  |

--- a/charts/litmus-core/README.md
+++ b/charts/litmus-core/README.md
@@ -24,7 +24,7 @@ A Helm chart to install litmus infra components on Kubernetes
 | affinity | object | `{}` |  |
 | customLabels | object | `{}` | Additional labels |
 | exporter.affinity | object | `{}` |  |
-| exporter.annotations | object | `{}` | |
+| exporter.annotations | object | `{}` |  |
 | exporter.enabled | bool | `false` |  |
 | exporter.image.pullPolicy | string | `"Always"` |  |
 | exporter.image.repository | string | `"litmuschaos/chaos-exporter"` |  |

--- a/charts/litmus-core/templates/exporter-deployment.yaml
+++ b/charts/litmus-core/templates/exporter-deployment.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     app: {{ template "litmus.name" . }}
     {{- include "litmus.labels" . | indent 4 }}
+  {{- if .Values.exporter.annotations }}
+  annotations:
+    {{- toYaml .Values.exporter.annotations | nindent 4 }}
+  {{- end }}
 spec:
   replicas: 1
   selector:
@@ -18,6 +22,10 @@ spec:
       labels:
         app: {{ template "litmus.name" . }}
         {{- include "litmus.labels" . | indent 8 }}
+        {{- if .Values.exporter.annotations }}
+        annotations:
+        {{- toYaml .Values.exporter.annotations | nindent 10 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "litmus.fullname" . }}
       serviceAccount: {{ include "litmus.fullname" . }}
@@ -25,7 +33,7 @@ spec:
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}
       containers:
-        - name: exporter
+        - name: litmus-exporter
           image: "{{ .Values.exporter.image.repository }}:{{ .Values.exporter.image.tag }}"
           imagePullPolicy: {{ .Values.exporter.image.pullPolicy }}
           env: 

--- a/charts/litmus-core/templates/exporter-deployment.yaml
+++ b/charts/litmus-core/templates/exporter-deployment.yaml
@@ -22,10 +22,10 @@ spec:
       labels:
         app: {{ template "litmus.name" . }}
         {{- include "litmus.labels" . | indent 8 }}
-        {{- if .Values.exporter.annotations }}
-        annotations:
+      {{- if .Values.exporter.annotations }}
+      annotations:
         {{- toYaml .Values.exporter.annotations | nindent 10 }}
-        {{- end }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "litmus.fullname" . }}
       serviceAccount: {{ include "litmus.fullname" . }}

--- a/charts/litmus-core/values.yaml
+++ b/charts/litmus-core/values.yaml
@@ -82,6 +82,8 @@ exporter:
     port: 8080
     annotations: {}
 
+  annotations: {}
+
   resources: {}
 
   nodeSelector: {}


### PR DESCRIPTION
This PR allows you to set custom annotations on the exporter deployment. This allows users to add custom Prometheus/DataDog annotations so the metrics can be scraped.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] DCO signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
