### PR TITLE
Switch to nindent for frontend like others

### DIFF
--- a/charts/litmus/Chart.yaml
+++ b/charts/litmus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2.14.0"
 description: A Helm chart to install ChaosCenter
 name: litmus
-version: 2.15.5
+version: 2.15.6
 kubeVersion: ">=1.16.0-0"
 home: https://litmuschaos.io
 sources:
@@ -21,7 +21,7 @@ maintainers:
 icon: https://raw.githubusercontent.com/litmuschaos/icons/master/litmus.png
 
 dependencies:
-- name: mongodb
-  version: "12.1.11"
-  repository: "https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami"
-  condition: mongodb.enabled
+  - name: mongodb
+    version: "12.1.11"
+    repository: "https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami"
+    condition: mongodb.enabled

--- a/charts/litmus/README.md
+++ b/charts/litmus/README.md
@@ -1,6 +1,6 @@
 # litmus
 
-![Version: 2.15.5](https://img.shields.io/badge/Version-2.15.5-informational?style=flat-square) ![AppVersion: 2.14.0](https://img.shields.io/badge/AppVersion-2.14.0-informational?style=flat-square)
+![Version: 2.15.6](https://img.shields.io/badge/Version-2.15.6-informational?style=flat-square) ![AppVersion: 2.14.0](https://img.shields.io/badge/AppVersion-2.14.0-informational?style=flat-square)
 
 A Helm chart to install ChaosCenter
 

--- a/charts/litmus/templates/auth-server-deployment.yaml
+++ b/charts/litmus/templates/auth-server-deployment.yaml
@@ -63,7 +63,7 @@ spec:
                 name: {{ include "litmus-portal.fullname" . }}-admin-config
           env:
             - name: DB_PASSWORD
-              {{- if .Values.mongodb.enabled }}      
+              {{- if .Values.mongodb.enabled }}
               {{- if not .Values.mongodb.auth.existingSecret }}
               value: {{ .Values.mongodb.auth.rootPassword }}
               {{- else }}

--- a/charts/litmus/templates/frontend-deployment.yaml
+++ b/charts/litmus/templates/frontend-deployment.yaml
@@ -15,7 +15,7 @@ spec:
   {{- end }}
   {{- if .Values.portal.frontend.updateStrategy }}
   strategy:
-  {{ toYaml .Values.portal.frontend.updateStrategy | indent 4 }}
+  {{ toYaml .Values.portal.frontend.updateStrategy | nindent 4 }}
   {{- end }}
   selector:
     matchLabels:
@@ -75,4 +75,3 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-


### PR DESCRIPTION
Sorry, should have used/tested locally instead of through Github UI - this fixes the indentation to `nindent` instead of `indent` which all other deployments are using.
