### PR TITLE
Give the update hook a unique name.

### DIFF
--- a/charts/litmus/Chart.yaml
+++ b/charts/litmus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2.14.0"
 description: A Helm chart to install ChaosCenter
 name: litmus
-version: 2.15.5
+version: 2.15.7
 kubeVersion: ">=1.16.0-0"
 home: https://litmuschaos.io
 sources:
@@ -21,7 +21,7 @@ maintainers:
 icon: https://raw.githubusercontent.com/litmuschaos/icons/master/litmus.png
 
 dependencies:
-- name: mongodb
-  version: "12.1.11"
-  repository: "https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami"
-  condition: mongodb.enabled
+  - name: mongodb
+    version: "12.1.11"
+    repository: "https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami"
+    condition: mongodb.enabled

--- a/charts/litmus/README.md
+++ b/charts/litmus/README.md
@@ -1,6 +1,6 @@
 # litmus
 
-![Version: 2.15.5](https://img.shields.io/badge/Version-2.15.5-informational?style=flat-square) ![AppVersion: 2.14.0](https://img.shields.io/badge/AppVersion-2.14.0-informational?style=flat-square)
+![Version: 2.15.7](https://img.shields.io/badge/Version-2.15.7-informational?style=flat-square) ![AppVersion: 2.14.0](https://img.shields.io/badge/AppVersion-2.14.0-informational?style=flat-square)
 
 A Helm chart to install ChaosCenter
 

--- a/charts/litmus/templates/post-upgrade-hook.yaml
+++ b/charts/litmus/templates/post-upgrade-hook.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "litmus-portal.fullname" . }}-upgrade-agent-cp
+  name: {{ include "litmus-portal.fullname" . }}-upgrade-agent-cp-{{.Release.Revision}}
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
@@ -26,7 +26,7 @@ spec:
       {{- if .Values.image.imagePullSecrets }}
       imagePullSecrets:
         {{ toYaml .Values.image.imagePullSecrets | nindent 8 }}
-      {{- end }}         
+      {{- end }}
       containers:
         - name: upgrade-agent
           image: {{ .Values.image.imageRegistryName }}/{{ .Values.upgradeAgent.controlPlane.image.repository }}:{{ .Values.upgradeAgent.controlPlane.image.tag }}
@@ -38,7 +38,7 @@ spec:
                 name: {{ include "litmus-portal.fullname" . }}-admin-config
           env:
             - name: DB_PASSWORD
-              {{- if .Values.mongodb.enabled }}      
+              {{- if .Values.mongodb.enabled }}
               {{- if not .Values.mongodb.auth.existingSecret }}
               value: {{ .Values.mongodb.auth.rootPassword }}
               {{- else }}


### PR DESCRIPTION
This prevents the following errors:

```
Error: UPGRADE FAILED: post-upgrade hooks failed: warning: Hook post-upgrade litmus/templates/post-upgrade-hook.yaml failed: jobs.batch "chaos-litmus-upgrade-agent-cp" already exists
```

and will produce a new job on each upgrade.


#### Checklist
- [X] DCO signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
