### PR TITLE
Remove hardcoded version of chaoscenter in pre-hook job in litmus-agent chart #329

### DIFF
--- a/charts/litmus-agent/Chart.yaml
+++ b/charts/litmus-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.2.0"
 description: A Helm chart to install litmus agent
 name: litmus-agent
-version: 0.2.0
+version: 0.2.1
 kubeVersion: ">=1.16.0-0"
 home: https://litmuschaos.io
 sources:

--- a/charts/litmus-agent/README.md
+++ b/charts/litmus-agent/README.md
@@ -1,6 +1,6 @@
 # litmus-agent
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
 
 A Helm chart to install litmus agent
 
@@ -55,6 +55,7 @@ $ helm install litmus-agent litmuschaos/litmus-agent \
 | AGENT_DESCRIPTION | string | `"chaos agent deployed with helm"` |  |
 | AGENT_NAME | string | `"helm-agent"` |  |
 | AGENT_NODE_SELECTOR | string | `""` |  |
+| APP_VERSION | string | `"3.0.0-beta8"` |  |
 | CLUSTER_TYPE | string | `"external"` |  |
 | LITMUS_BACKEND_URL | string | `""` |  |
 | LITMUS_PASSWORD | string | `"litmus"` |  |

--- a/charts/litmus-agent/templates/hook-pre-install-job.yaml
+++ b/charts/litmus-agent/templates/hook-pre-install-job.yaml
@@ -64,7 +64,7 @@ spec:
             value: {{ .Release.Namespace }}
 
           - name: APP_VERSION 
-            value: "3.0.0-beta8" #For compatibility with 3.0.0-beta8 ChaosCenter, Version has to be same
+            value: {{ .Values.APP_VERSION }}
 
           - name: SERVICE_ACCOUNT_NAME
             value: {{ include "litmus-agent.serviceAccountName" . }}

--- a/charts/litmus-agent/values.yaml
+++ b/charts/litmus-agent/values.yaml
@@ -16,6 +16,7 @@ AGENT_NODE_SELECTOR: ""
 SA_EXISTS: true
 NS_EXISTS: true
 CLUSTER_TYPE: "external"
+APP_VERSION: "3.0.0-beta8" #For compatibility with 3.0.0-beta8 ChaosCenter, Version has to be same
 SKIP_SSL: "false"
 
 # PLATFORM_NAME: AWS, GKE, Openshift, Rancher, Others

--- a/charts/litmus-agent/values.yaml
+++ b/charts/litmus-agent/values.yaml
@@ -16,7 +16,8 @@ AGENT_NODE_SELECTOR: ""
 SA_EXISTS: true
 NS_EXISTS: true
 CLUSTER_TYPE: "external"
-APP_VERSION: "3.0.0-beta8" #For compatibility with 3.0.0-beta8 ChaosCenter, Version has to be same
+# For compatibility with 3.0.0-beta8 ChaosCenter, Version has to be same
+APP_VERSION: "3.0.0-beta8"
 SKIP_SSL: "false"
 
 # PLATFORM_NAME: AWS, GKE, Openshift, Rancher, Others


### PR DESCRIPTION
<!--

* https://github.com/helm/helm/tree/master/docs/chart_best_practices

Following best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

The version of the chaoscenter was hardcoded in the template of the litmus-agent charts that was posing problem when deploying with different version of chaoscenter. The version is now a variable.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #329 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] DCO signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
