### PR TITLE
Add security context for wait-for-mongodb

### DIFF
--- a/charts/litmus/Chart.yaml
+++ b/charts/litmus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2.14.0"
 description: A Helm chart to install ChaosCenter
 name: litmus
-version: 2.15.10
+version: 2.16.0
 kubeVersion: ">=1.16.0-0"
 home: https://litmuschaos.io
 sources:

--- a/charts/litmus/Chart.yaml
+++ b/charts/litmus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2.14.0"
 description: A Helm chart to install ChaosCenter
 name: litmus
-version: 2.16.0
+version: 2.15.11
 kubeVersion: ">=1.16.0-0"
 home: https://litmuschaos.io
 sources:

--- a/charts/litmus/README.md
+++ b/charts/litmus/README.md
@@ -1,6 +1,6 @@
 # litmus
 
-![Version: 2.16.0](https://img.shields.io/badge/Version-2.16.0-informational?style=flat-square) ![AppVersion: 2.14.0](https://img.shields.io/badge/AppVersion-2.14.0-informational?style=flat-square)
+![Version: 2.15.11](https://img.shields.io/badge/Version-2.15.11-informational?style=flat-square) ![AppVersion: 2.14.0](https://img.shields.io/badge/AppVersion-2.14.0-informational?style=flat-square)
 
 A Helm chart to install ChaosCenter
 
@@ -229,10 +229,7 @@ We separated service configuration from `portal.server.service` to `portal.serve
 | portal.server.waitForMongodb.resources.requests.cpu | string | `"25m"` |  |
 | portal.server.waitForMongodb.resources.requests.ephemeral-storage | string | `"500Mi"` |  |
 | portal.server.waitForMongodb.resources.requests.memory | string | `"150Mi"` |  |
-| portal.server.waitForMongodb.securityContext.allowPrivilegeEscalation | bool | `false` |  |
-| portal.server.waitForMongodb.securityContext.readOnlyRootFilesystem | bool | `true` |  |
-| portal.server.waitForMongodb.securityContext.runAsNonRoot | bool | `true` |  |
-| portal.server.waitForMongodb.securityContext.runAsUser | int | `101` |  |
+| portal.server.waitForMongodb.securityContext | object | `{}` |  |
 | portalScope | string | `"cluster"` |  |
 | upgradeAgent.affinity | object | `{}` |  |
 | upgradeAgent.controlPlane.image.pullPolicy | string | `"Always"` |  |

--- a/charts/litmus/README.md
+++ b/charts/litmus/README.md
@@ -1,6 +1,6 @@
 # litmus
 
-![Version: 2.15.10](https://img.shields.io/badge/Version-2.15.10-informational?style=flat-square) ![AppVersion: 2.14.0](https://img.shields.io/badge/AppVersion-2.14.0-informational?style=flat-square)
+![Version: 2.16.0](https://img.shields.io/badge/Version-2.16.0-informational?style=flat-square) ![AppVersion: 2.14.0](https://img.shields.io/badge/AppVersion-2.14.0-informational?style=flat-square)
 
 A Helm chart to install ChaosCenter
 
@@ -229,6 +229,10 @@ We separated service configuration from `portal.server.service` to `portal.serve
 | portal.server.waitForMongodb.resources.requests.cpu | string | `"25m"` |  |
 | portal.server.waitForMongodb.resources.requests.ephemeral-storage | string | `"500Mi"` |  |
 | portal.server.waitForMongodb.resources.requests.memory | string | `"150Mi"` |  |
+| portal.server.waitForMongodb.securityContext.allowPrivilegeEscalation | bool | `false` |  |
+| portal.server.waitForMongodb.securityContext.readOnlyRootFilesystem | bool | `true` |  |
+| portal.server.waitForMongodb.securityContext.runAsNonRoot | bool | `true` |  |
+| portal.server.waitForMongodb.securityContext.runAsUser | int | `101` |  |
 | portalScope | string | `"cluster"` |  |
 | upgradeAgent.affinity | object | `{}` |  |
 | upgradeAgent.controlPlane.image.pullPolicy | string | `"Always"` |  |

--- a/charts/litmus/templates/auth-server-deployment.yaml
+++ b/charts/litmus/templates/auth-server-deployment.yaml
@@ -46,6 +46,8 @@ spec:
             ]
           resources:
             {{- toYaml .Values.portal.server.waitForMongodb.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.portal.server.waitForMongodb.securityContext | nindent 12 }}
       containers:
         - name: auth-server
           image: {{ .Values.image.imageRegistryName }}/{{ .Values.portal.server.authServer.image.repository }}:{{ .Values.portal.server.authServer.image.tag }}

--- a/charts/litmus/templates/server-deployment.yaml
+++ b/charts/litmus/templates/server-deployment.yaml
@@ -43,6 +43,8 @@ spec:
             [
                 "while [[ $(curl -sw '%{http_code}' http://{{ include "litmus-portal.mongodbServiceName" . }}:{{ .Values.mongodb.service.ports.mongodb }} -o /dev/null) -ne 200 ]]; do sleep 5; echo 'Waiting for the MongoDB to be ready...'; done; echo 'Connection with MongoDB established'",
             ]
+          securityContext:
+            {{- toYaml .Values.portal.server.waitForMongodb.securityContext | nindent 12 }}
           resources:
             {{- toYaml .Values.portal.server.waitForMongodb.resources | nindent 12 }}
       containers:

--- a/charts/litmus/values.yaml
+++ b/charts/litmus/values.yaml
@@ -168,11 +168,11 @@ portal:
         repository: curl
         tag: 2.14.0
         pullPolicy: "Always"
-      securityContext:
-        runAsUser: 101
-        allowPrivilegeEscalation: false
-        runAsNonRoot: true
-        readOnlyRootFilesystem: true
+      securityContext: {}
+       # runAsUser: 101
+       # allowPrivilegeEscalation: false
+       # runAsNonRoot: true
+       # readOnlyRootFilesystem: true
       resources:
         # We usually recommend not to specify default resources and to leave this as a conscious
         # choice for the user. This also increases chances charts run on environments with little

--- a/charts/litmus/values.yaml
+++ b/charts/litmus/values.yaml
@@ -168,6 +168,11 @@ portal:
         repository: curl
         tag: 2.14.0
         pullPolicy: "Always"
+      securityContext:
+        runAsUser: 101
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
+        readOnlyRootFilesystem: true
       resources:
         # We usually recommend not to specify default resources and to leave this as a conscious
         # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
- Add securityContext in values.yaml
- Using this securityContext in auth-server-deployment.yaml and server-deployment.yaml
- Bumping Chart version to 2.16.0 (I hesitate between bumping to 2.16.0 or 2.15.12 cause not sure if this change can be considered a bug fix)
- Regenerating docs with helm-docs

<!--

* https://github.com/helm/helm/tree/master/docs/chart_best_practices

Following best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #331

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] DCO signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
