### PR TITLE
Integrate the litmus images with scarf gateway

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
         uses: mayadata-io/github-chaos-actions@v0.4.0
         env:
           EXPERIMENT_NAME: pod-delete
-          EXPERIMENT_IMAGE: litmuschaos/go-runner
+          EXPERIMENT_IMAGE: litmuschaos.docker.scarf.sh/litmuschaos/go-runner
           EXPERIMENT_IMAGE_TAG: ci
           JOB_CLEANUP_POLICY: delete
 
@@ -95,7 +95,7 @@ jobs:
         uses: mayadata-io/github-chaos-actions@v0.4.0
         env:
           EXPERIMENT_NAME: container-kill
-          EXPERIMENT_IMAGE: litmuschaos/go-runner
+          EXPERIMENT_IMAGE: litmuschaos.docker.scarf.sh/litmuschaos/go-runner
           EXPERIMENT_IMAGE_TAG: ci
           JOB_CLEANUP_POLICY: delete
           CONTAINER_RUNTIME: containerd
@@ -112,7 +112,7 @@ jobs:
         uses: mayadata-io/github-chaos-actions@v0.4.0
         env:
           EXPERIMENT_NAME: node-cpu-hog
-          EXPERIMENT_IMAGE: litmuschaos/go-runner
+          EXPERIMENT_IMAGE: litmuschaos.docker.scarf.sh/litmuschaos/go-runner
           EXPERIMENT_IMAGE_TAG: ci
           JOB_CLEANUP_POLICY: delete
 
@@ -128,7 +128,7 @@ jobs:
         uses: mayadata-io/github-chaos-actions@v0.4.0
         env:
           EXPERIMENT_NAME: node-memory-hog
-          EXPERIMENT_IMAGE: litmuschaos/go-runner
+          EXPERIMENT_IMAGE: litmuschaos.docker.scarf.sh/litmuschaos/go-runner
           EXPERIMENT_IMAGE_TAG: ci
           JOB_CLEANUP_POLICY: delete
 
@@ -145,7 +145,7 @@ jobs:
         uses: mayadata-io/github-chaos-actions@v0.4.0
         env:
           EXPERIMENT_NAME: pod-cpu-hog
-          EXPERIMENT_IMAGE: litmuschaos/go-runner
+          EXPERIMENT_IMAGE: litmuschaos.docker.scarf.sh/litmuschaos/go-runner
           EXPERIMENT_IMAGE_TAG: ci
           JOB_CLEANUP_POLICY: delete
           TARGET_CONTAINER: nginx
@@ -165,7 +165,7 @@ jobs:
         uses: mayadata-io/github-chaos-actions@v0.4.0
         env:
           EXPERIMENT_NAME: pod-cpu-hog
-          EXPERIMENT_IMAGE: litmuschaos/go-runner
+          EXPERIMENT_IMAGE: litmuschaos.docker.scarf.sh/litmuschaos/go-runner
           EXPERIMENT_IMAGE_TAG: ci
           JOB_CLEANUP_POLICY: delete
           TARGET_CONTAINER: nginx
@@ -185,7 +185,7 @@ jobs:
         uses: mayadata-io/github-chaos-actions@v0.4.0
         env:
           EXPERIMENT_NAME: pod-network-corruption
-          EXPERIMENT_IMAGE: litmuschaos/go-runner
+          EXPERIMENT_IMAGE: litmuschaos.docker.scarf.sh/litmuschaos/go-runner
           EXPERIMENT_IMAGE_TAG: ci
           JOB_CLEANUP_POLICY: delete
           TARGET_CONTAINER: nginx
@@ -205,7 +205,7 @@ jobs:
         uses: mayadata-io/github-chaos-actions@v0.4.0
         env:
           EXPERIMENT_NAME: pod-network-duplication
-          EXPERIMENT_IMAGE: litmuschaos/go-runner
+          EXPERIMENT_IMAGE: litmuschaos.docker.scarf.sh/litmuschaos/go-runner
           EXPERIMENT_IMAGE_TAG: ci
           JOB_CLEANUP_POLICY: delete
           TARGET_CONTAINER: nginx
@@ -226,7 +226,7 @@ jobs:
         uses: mayadata-io/github-chaos-actions@v0.4.0
         env:
           EXPERIMENT_NAME: pod-network-latency
-          EXPERIMENT_IMAGE: litmuschaos/go-runner
+          EXPERIMENT_IMAGE: litmuschaos.docker.scarf.sh/litmuschaos/go-runner
           EXPERIMENT_IMAGE_TAG: ci
           JOB_CLEANUP_POLICY: delete
           TARGET_CONTAINER: nginx
@@ -247,7 +247,7 @@ jobs:
         uses: mayadata-io/github-chaos-actions@v0.4.0
         env:
           EXPERIMENT_NAME: pod-network-loss
-          EXPERIMENT_IMAGE: litmuschaos/go-runner
+          EXPERIMENT_IMAGE: litmuschaos.docker.scarf.sh/litmuschaos/go-runner
           EXPERIMENT_IMAGE_TAG: ci
           JOB_CLEANUP_POLICY: delete
           TARGET_CONTAINER: nginx
@@ -269,7 +269,7 @@ jobs:
         uses: mayadata-io/github-chaos-actions@v0.4.0
         env:
           EXPERIMENT_NAME: pod-autoscaler
-          EXPERIMENT_IMAGE: litmuschaos/go-runner
+          EXPERIMENT_IMAGE: litmuschaos.docker.scarf.sh/litmuschaos/go-runner
           EXPERIMENT_IMAGE_TAG: ci
           JOB_CLEANUP_POLICY: delete
           TOTAL_CHAOS_DURATION: 60
@@ -287,7 +287,7 @@ jobs:
         uses: mayadata-io/github-chaos-actions@v0.4.0
         env:
           EXPERIMENT_NAME: node-io-stress
-          EXPERIMENT_IMAGE: litmuschaos/go-runner
+          EXPERIMENT_IMAGE: litmuschaos.docker.scarf.sh/litmuschaos/go-runner
           EXPERIMENT_IMAGE_TAG: ci
           JOB_CLEANUP_POLICY: delete
           TOTAL_CHAOS_DURATION: 120

--- a/charts/kube-aws/Chart.yaml
+++ b/charts/kube-aws/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.14.0"
 description: A Helm chart to install litmus aws chaos experiments
 name: kube-aws
-version: 2.14.0
+version: 2.14.1
 home: https://litmuschaos.io
 sources:
   - https://github.com/litmuschaos/litmus

--- a/charts/kube-aws/README.md
+++ b/charts/kube-aws/README.md
@@ -1,6 +1,6 @@
 # kube-aws
 
-![Version: 2.14.0](https://img.shields.io/badge/Version-2.14.0-informational?style=flat-square) ![AppVersion: 2.14.0](https://img.shields.io/badge/AppVersion-2.14.0-informational?style=flat-square)
+![Version: 2.14.1](https://img.shields.io/badge/Version-2.14.1-informational?style=flat-square) ![AppVersion: 2.14.0](https://img.shields.io/badge/AppVersion-2.14.0-informational?style=flat-square)
 
 A Helm chart to install litmus aws chaos experiments
 

--- a/charts/kube-aws/README.md
+++ b/charts/kube-aws/README.md
@@ -26,7 +26,7 @@ A Helm chart to install litmus aws chaos experiments
 | experiments.disabled | list | `[]` |  |
 | fullnameOverride | string | `"kube-aws"` |  |
 | image.litmusGO.pullPolicy | string | `"Always"` |  |
-| image.litmusGO.repository | string | `"litmuschaos/go-runner"` |  |
+| image.litmusGO.repository | string | `"litmuschaos.docker.scarf.sh/litmuschaos/go-runner"` |  |
 | image.litmusGO.tag | string | `"2.14.0"` |  |
 | nameOverride | string | `"kube-aws"` |  |
 

--- a/charts/kube-aws/values.yaml
+++ b/charts/kube-aws/values.yaml
@@ -10,7 +10,7 @@ customLabels: {}
 
 image:
   litmusGO:
-    repository: litmuschaos/go-runner
+    repository: litmuschaos.docker.scarf.sh/litmuschaos/go-runner
     tag: 2.14.0
     pullPolicy: Always
 

--- a/charts/kube-azure/Chart.yaml
+++ b/charts/kube-azure/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.14.0"
 description: A Helm chart to install litmus Azure chaos experiments
 name: kube-azure
-version: 2.14.0
+version: 2.14.1
 home: https://litmuschaos.io
 sources:
   - https://github.com/litmuschaos/litmus

--- a/charts/kube-azure/README.md
+++ b/charts/kube-azure/README.md
@@ -26,7 +26,7 @@ A Helm chart to install litmus Azure chaos experiments
 | experiments.disabled | list | `[]` |  |
 | fullnameOverride | string | `"kube-azure"` |  |
 | image.litmusGO.pullPolicy | string | `"Always"` |  |
-| image.litmusGO.repository | string | `"litmuschaos/go-runner"` |  |
+| image.litmusGO.repository | string | `"litmuschaos.docker.scarf.sh/litmuschaos/go-runner"` |  |
 | image.litmusGO.tag | string | `"2.14.0"` |  |
 | nameOverride | string | `"kube-azure"` |  |
 

--- a/charts/kube-azure/README.md
+++ b/charts/kube-azure/README.md
@@ -1,6 +1,6 @@
 # kube-azure
 
-![Version: 2.14.0](https://img.shields.io/badge/Version-2.14.0-informational?style=flat-square) ![AppVersion: 2.14.0](https://img.shields.io/badge/AppVersion-2.14.0-informational?style=flat-square)
+![Version: 2.14.1](https://img.shields.io/badge/Version-2.14.1-informational?style=flat-square) ![AppVersion: 2.14.0](https://img.shields.io/badge/AppVersion-2.14.0-informational?style=flat-square)
 
 A Helm chart to install litmus Azure chaos experiments
 

--- a/charts/kube-azure/values.yaml
+++ b/charts/kube-azure/values.yaml
@@ -10,7 +10,7 @@ customLabels: {}
 
 image:
   litmusGO:
-    repository: litmuschaos/go-runner
+    repository: litmuschaos.docker.scarf.sh/litmuschaos/go-runner
     tag: 2.14.0
     pullPolicy: Always
 

--- a/charts/kube-gcp/Chart.yaml
+++ b/charts/kube-gcp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.14.0"
 description: A Helm chart to install litmus gcp chaos experiments
 name: kube-gcp
-version: 2.14.0
+version: 2.14.1
 home: https://litmuschaos.io
 sources:
   - https://github.com/litmuschaos/litmus

--- a/charts/kube-gcp/README.md
+++ b/charts/kube-gcp/README.md
@@ -1,6 +1,6 @@
 # kube-gcp
 
-![Version: 2.14.0](https://img.shields.io/badge/Version-2.14.0-informational?style=flat-square) ![AppVersion: 2.14.0](https://img.shields.io/badge/AppVersion-2.14.0-informational?style=flat-square)
+![Version: 2.14.1](https://img.shields.io/badge/Version-2.14.1-informational?style=flat-square) ![AppVersion: 2.14.0](https://img.shields.io/badge/AppVersion-2.14.0-informational?style=flat-square)
 
 A Helm chart to install litmus gcp chaos experiments
 

--- a/charts/kube-gcp/README.md
+++ b/charts/kube-gcp/README.md
@@ -26,7 +26,7 @@ A Helm chart to install litmus gcp chaos experiments
 | experiments.disabled | list | `[]` |  |
 | fullnameOverride | string | `"kube-gcp"` |  |
 | image.litmusGO.pullPolicy | string | `"Always"` |  |
-| image.litmusGO.repository | string | `"litmuschaos/go-runner"` |  |
+| image.litmusGO.repository | string | `"litmuschaos.docker.scarf.sh/litmuschaos/go-runner"` |  |
 | image.litmusGO.tag | string | `"2.14.0"` |  |
 | nameOverride | string | `"kube-gcp"` |  |
 

--- a/charts/kube-gcp/values.yaml
+++ b/charts/kube-gcp/values.yaml
@@ -10,7 +10,7 @@ customLabels: {}
 
 image:
   litmusGO:
-    repository: litmuschaos/go-runner
+    repository: litmuschaos.docker.scarf.sh/litmuschaos/go-runner
     tag: 2.14.0
     pullPolicy: Always
 

--- a/charts/kubernetes-chaos/Chart.yaml
+++ b/charts/kubernetes-chaos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.14.0"
 description: A Helm chart to install litmus chaos experiments for kubernetes category (chaos-chart)
 name: kubernetes-chaos
-version: 2.28.0
+version: 2.28.1
 home: https://litmuschaos.io
 sources:
   - https://github.com/litmuschaos/litmus

--- a/charts/kubernetes-chaos/README.md
+++ b/charts/kubernetes-chaos/README.md
@@ -1,6 +1,6 @@
 # kubernetes-chaos
 
-![Version: 2.28.0](https://img.shields.io/badge/Version-2.28.0-informational?style=flat-square) ![AppVersion: 2.14.0](https://img.shields.io/badge/AppVersion-2.14.0-informational?style=flat-square)
+![Version: 2.28.1](https://img.shields.io/badge/Version-2.28.1-informational?style=flat-square) ![AppVersion: 2.14.0](https://img.shields.io/badge/AppVersion-2.14.0-informational?style=flat-square)
 
 A Helm chart to install litmus chaos experiments for kubernetes category (chaos-chart)
 
@@ -29,7 +29,7 @@ A Helm chart to install litmus chaos experiments for kubernetes category (chaos-
 | experiments.disabled | list | `[]` |  |
 | fullnameOverride | string | `"k8s"` |  |
 | image.litmus.pullPolicy | string | `"Always"` |  |
-| image.litmus.repository | string | `"litmuschaos/ansible-runner"` |  |
+| image.litmus.repository | string | `"litmuschaos.docker.scarf.sh/litmuschaos/ansible-runner"` |  |
 | image.litmus.tag | string | `"2.14.0"` |  |
 | image.litmusGO.pullPolicy | string | `"Always"` |  |
 | image.litmusGO.repository | string | `"litmuschaos.docker.scarf.sh/litmuschaos/go-runner"` |  |

--- a/charts/kubernetes-chaos/README.md
+++ b/charts/kubernetes-chaos/README.md
@@ -32,9 +32,9 @@ A Helm chart to install litmus chaos experiments for kubernetes category (chaos-
 | image.litmus.repository | string | `"litmuschaos/ansible-runner"` |  |
 | image.litmus.tag | string | `"2.14.0"` |  |
 | image.litmusGO.pullPolicy | string | `"Always"` |  |
-| image.litmusGO.repository | string | `"litmuschaos/go-runner"` |  |
+| image.litmusGO.repository | string | `"litmuschaos.docker.scarf.sh/litmuschaos/go-runner"` |  |
 | image.litmusGO.tag | string | `"2.14.0"` |  |
-| image.litmusLIBImage.repository | string | `"litmuschaos/go-runner"` |  |
+| image.litmusLIBImage.repository | string | `"litmuschaos.docker.scarf.sh/litmuschaos/go-runner"` |  |
 | image.litmusLIBImage.tag | string | `"2.14.0"` |  |
 | image.networkChaos.tcImage | string | `"gaiadocker/iproute2"` |  |
 | image.pumba.libName | string | `"pumba"` |  |

--- a/charts/kubernetes-chaos/values.yaml
+++ b/charts/kubernetes-chaos/values.yaml
@@ -10,12 +10,12 @@ customLabels: {}
 
 image:
   litmus:
-    repository: litmuschaos/ansible-runner
+    repository: litmuschaos.docker.scarf.sh/litmuschaos/ansible-runner
     tag: 2.14.0
     pullPolicy: Always
 
   litmusGO:
-    repository: litmuschaos/go-runner
+    repository: litmuschaos.docker.scarf.sh/litmuschaos/go-runner
     tag: 2.14.0
     pullPolicy: Always
 
@@ -23,7 +23,7 @@ image:
     libName: pumba
 
   litmusLIBImage:
-    repository: litmuschaos/go-runner
+    repository: litmuschaos.docker.scarf.sh/litmuschaos/go-runner
     tag: 2.14.0
 
   networkChaos:

--- a/charts/litmus-agent/Chart.yaml
+++ b/charts/litmus-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.2.0"
 description: A Helm chart to install litmus agent
 name: litmus-agent
-version: 0.2.0
+version: 0.2.1
 kubeVersion: ">=1.16.0-0"
 home: https://litmuschaos.io
 sources:

--- a/charts/litmus-agent/README.md
+++ b/charts/litmus-agent/README.md
@@ -1,6 +1,6 @@
 # litmus-agent
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
 
 A Helm chart to install litmus agent
 
@@ -75,7 +75,7 @@ $ helm install litmus-agent litmuschaos/litmus-agent \
 | global.customLabels | object | `{}` |  |
 | global.podAnnotations | object | `{}` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"litmuschaos/litmus-helm-agent"` |  |
+| image.repository | string | `"litmuschaos.docker.scarf.sh/litmuschaos/litmus-helm-agent"` |  |
 | image.tag | string | `"latest"` |  |
 | resources.limits.cpu | string | `"100m"` |  |
 | resources.limits.memory | string | `"128Mi"` |  |

--- a/charts/litmus-agent/charts/chaos-exporter/README.md
+++ b/charts/litmus-agent/charts/chaos-exporter/README.md
@@ -36,7 +36,7 @@ Kubernetes: `>=1.16.0-0`
 | enabled | bool | `true` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"litmuschaos/chaos-exporter"` |  |
+| image.repository | string | `"litmuschaos.docker.scarf.sh/litmuschaos/chaos-exporter"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | nameOverride | string | `""` |  |

--- a/charts/litmus-agent/charts/chaos-exporter/values.yaml
+++ b/charts/litmus-agent/charts/chaos-exporter/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: litmuschaos/chaos-exporter
+  repository: litmuschaos.docker.scarf.sh/litmuschaos/chaos-exporter
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/charts/litmus-agent/charts/chaos-operator/README.md
+++ b/charts/litmus-agent/charts/chaos-operator/README.md
@@ -34,7 +34,7 @@ Kubernetes: `>=1.16.0-0`
 | customLabels | object | `{}` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"litmuschaos/chaos-operator"` |  |
+| image.repository | string | `"litmuschaos.docker.scarf.sh/litmuschaos/chaos-operator"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
@@ -55,7 +55,7 @@ Kubernetes: `>=1.16.0-0`
 | resources.requests.cpu | string | `"125m"` |  |
 | resources.requests.ephemeral-storage | string | `"500Mi"` |  |
 | resources.requests.memory | string | `"300Mi"` |  |
-| runner.image.repository | string | `"litmuschaos/chaos-runner"` |  |
+| runner.image.repository | string | `"litmuschaos.docker.scarf.sh/litmuschaos/chaos-runner"` |  |
 | runner.image.tag | string | `""` |  |
 | securityContext.allowPrivilegeEscalation | bool | `false` |  |
 | securityContext.runAsUser | int | `2000` |  |

--- a/charts/litmus-agent/charts/chaos-operator/values.yaml
+++ b/charts/litmus-agent/charts/chaos-operator/values.yaml
@@ -5,14 +5,14 @@
 replicaCount: 1
 
 image:
-  repository: litmuschaos/chaos-operator
+  repository: litmuschaos.docker.scarf.sh/litmuschaos/chaos-operator
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
 runner:
   image:
-    repository: litmuschaos/chaos-runner
+    repository: litmuschaos.docker.scarf.sh/litmuschaos/chaos-runner
     tag: ""
 
 imagePullSecrets: []

--- a/charts/litmus-agent/charts/event-tracker/README.md
+++ b/charts/litmus-agent/charts/event-tracker/README.md
@@ -36,7 +36,7 @@ Kubernetes: `>=1.16.0-0`
 | global.agentConfigName | string | `"agent-config"` |  |
 | global.agentSecretName | string | `"agent-secret"` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"litmuschaos/litmusportal-event-tracker"` |  |
+| image.repository | string | `"litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-event-tracker"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | nameOverride | string | `""` |  |

--- a/charts/litmus-agent/charts/event-tracker/values.yaml
+++ b/charts/litmus-agent/charts/event-tracker/values.yaml
@@ -8,7 +8,7 @@ global:
 replicaCount: 1
 
 image:
-  repository: litmuschaos/litmusportal-event-tracker
+  repository: litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-event-tracker
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/charts/litmus-agent/charts/subscriber/README.md
+++ b/charts/litmus-agent/charts/subscriber/README.md
@@ -34,7 +34,7 @@ Kubernetes: `>=1.16.0-0`
 | global.agentConfigName | string | `"agent-config"` |  |
 | global.agentSecretName | string | `"agent-secret"` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"litmuschaos/litmusportal-subscriber"` |  |
+| image.repository | string | `"litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-subscriber"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | nameOverride | string | `""` |  |

--- a/charts/litmus-agent/charts/subscriber/values.yaml
+++ b/charts/litmus-agent/charts/subscriber/values.yaml
@@ -5,14 +5,14 @@ global:
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-appSettings: 
+appSettings:
   executorImage: "litmuschaos/argoexec:v3.3.1"
   containerRuntimeExecutor: "k8sapi"
 
 replicaCount: 1
 
 image:
-  repository: litmuschaos/litmusportal-subscriber
+  repository: litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-subscriber
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/charts/litmus-agent/charts/workflow-controller/README.md
+++ b/charts/litmus-agent/charts/workflow-controller/README.md
@@ -38,7 +38,7 @@ Kubernetes: `>=1.16.0-0`
 | customLabels | object | `{}` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"litmuschaos/workflow-controller"` |  |
+| image.repository | string | `"litmuschaos.docker.scarf.sh/litmuschaos/workflow-controller"` |  |
 | image.tag | string | `"v3.3.1"` |  |
 | imagePullSecrets | list | `[]` |  |
 | nameOverride | string | `""` |  |

--- a/charts/litmus-agent/charts/workflow-controller/values.yaml
+++ b/charts/litmus-agent/charts/workflow-controller/values.yaml
@@ -13,7 +13,7 @@ crds:
 replicaCount: 1
 
 image:
-  repository: litmuschaos/workflow-controller
+  repository: litmuschaos.docker.scarf.sh/litmuschaos/workflow-controller
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: "v3.3.1"

--- a/charts/litmus-agent/values.yaml
+++ b/charts/litmus-agent/values.yaml
@@ -28,7 +28,7 @@ LITMUS_PASSWORD: "litmus"
 LITMUS_PROJECT_ID: ""
 
 image:
-  repository: litmuschaos/litmus-helm-agent
+  repository: litmuschaos.docker.scarf.sh/litmuschaos/litmus-helm-agent
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"

--- a/charts/litmus-core/Chart.yaml
+++ b/charts/litmus-core/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.14.0"
 description: A Helm chart to install litmus infra components on Kubernetes
 name: litmus-core
-version: 2.14.0
+version: 2.14.1
 home: https://litmuschaos.io
 sources:
   - https://github.com/litmuschaos/litmus

--- a/charts/litmus-core/README.md
+++ b/charts/litmus-core/README.md
@@ -1,6 +1,6 @@
 # litmus-core
 
-![Version: 2.14.0](https://img.shields.io/badge/Version-2.14.0-informational?style=flat-square) ![AppVersion: 2.14.0](https://img.shields.io/badge/AppVersion-2.14.0-informational?style=flat-square)
+![Version: 2.14.1](https://img.shields.io/badge/Version-2.14.1-informational?style=flat-square) ![AppVersion: 2.14.0](https://img.shields.io/badge/AppVersion-2.14.0-informational?style=flat-square)
 
 A Helm chart to install litmus infra components on Kubernetes
 
@@ -27,7 +27,7 @@ A Helm chart to install litmus infra components on Kubernetes
 | exporter.annotations | object | `{}` |  |
 | exporter.enabled | bool | `false` |  |
 | exporter.image.pullPolicy | string | `"Always"` |  |
-| exporter.image.repository | string | `"litmuschaos/chaos-exporter"` |  |
+| exporter.image.repository | string | `"litmuschaos.docker.scarf.sh/litmuschaos/chaos-exporter"` |  |
 | exporter.image.tag | string | `"2.14.0"` |  |
 | exporter.nodeSelector | object | `{}` |  |
 | exporter.priorityClassName | string | `nil` |  |
@@ -47,7 +47,7 @@ A Helm chart to install litmus infra components on Kubernetes
 | nameOverride | string | `"litmus"` |  |
 | nodeSelector | object | `{}` |  |
 | operator.image.pullPolicy | string | `"Always"` |  |
-| operator.image.repository | string | `"litmuschaos/chaos-operator"` |  |
+| operator.image.repository | string | `"litmuschaos.docker.scarf.sh/litmuschaos/chaos-operator"` |  |
 | operator.image.tag | string | `"2.14.0"` |  |
 | operatorMode | string | `"standard"` |  |
 | operatorName | string | `"chaos-operator"` |  |
@@ -57,7 +57,7 @@ A Helm chart to install litmus infra components on Kubernetes
 | resources.limits.memory | string | `"128Mi"` |  |
 | resources.requests.cpu | string | `"100m"` |  |
 | resources.requests.memory | string | `"128Mi"` |  |
-| runner.image.repository | string | `"litmuschaos/chaos-runner"` |  |
+| runner.image.repository | string | `"litmuschaos.docker.scarf.sh/litmuschaos/chaos-runner"` |  |
 | runner.image.tag | string | `"2.14.0"` |  |
 | service.port | int | `80` |  |
 | service.type | string | `"ClusterIP"` |  |

--- a/charts/litmus-core/values.yaml
+++ b/charts/litmus-core/values.yaml
@@ -14,12 +14,12 @@ replicaCount: 1
 
 operator:
   image:
-    repository: litmuschaos/chaos-operator
+    repository: litmuschaos.docker.scarf.sh/litmuschaos/chaos-operator
     tag: 2.14.0
     pullPolicy: Always
 runner:
   image:
-    repository: litmuschaos/chaos-runner
+    repository: litmuschaos.docker.scarf.sh/litmuschaos/chaos-runner
     tag: 2.14.0
 
 service:
@@ -74,7 +74,7 @@ exporter:
     enabled: false
     additionalLabels: {}
   image:
-    repository: litmuschaos/chaos-exporter
+    repository: litmuschaos.docker.scarf.sh/litmuschaos/chaos-exporter
     tag: 2.14.0
     pullPolicy: Always
   service:

--- a/charts/litmus-core/values.yaml
+++ b/charts/litmus-core/values.yaml
@@ -46,12 +46,12 @@ resources:
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    limits:
-      cpu: 100m
-      memory: 128Mi
-    requests:
-      cpu: 100m
-      memory: 128Mi
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
 
 nodeSelector: {}
 

--- a/charts/litmus/Chart.yaml
+++ b/charts/litmus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.0.0"
 description: A Helm chart to install ChaosCenter
 name: litmus
-version: 3.0.2
+version: 3.0.3
 kubeVersion: ">=1.16.0-0"
 home: https://litmuschaos.io
 sources:

--- a/charts/litmus/README.md
+++ b/charts/litmus/README.md
@@ -1,6 +1,6 @@
 # litmus
 
-![Version: 3.0.2](https://img.shields.io/badge/Version-3.0.2-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
+![Version: 3.0.3](https://img.shields.io/badge/Version-3.0.3-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
 
 A Helm chart to install ChaosCenter
 
@@ -61,7 +61,7 @@ We separated service configuration from `portal.server.service` to `portal.serve
 | customLabels | object | `{}` | Additional labels |
 | existingSecret | string | `""` | Use existing secret (e.g., External Secrets) |
 | image.imagePullSecrets | list | `[]` |  |
-| image.imageRegistryName | string | `"litmuschaos"` |  |
+| image.imageRegistryName | string | `"litmuschaos.docker.scarf.sh/litmuschaos"` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |
 | ingress.host.backend.path | string | `"/backend/(.*)"` | You may need adapt the path depending your ingress-controller |

--- a/charts/litmus/values.yaml
+++ b/charts/litmus/values.yaml
@@ -26,7 +26,7 @@ adminConfig:
   ADMIN_PASSWORD: "litmus"
 
 image:
-  imageRegistryName: litmuschaos
+  imageRegistryName: litmuschaos.docker.scarf.sh/litmuschaos
   # Optional pod imagePullSecrets
   imagePullSecrets: []
 

--- a/ct.yaml
+++ b/ct.yaml
@@ -2,3 +2,4 @@ chart-dirs:
   - charts
 chart-repos:
   - bitnami=https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+excluded-charts: "litmus-agent"


### PR DESCRIPTION
<!--

* https://github.com/helm/helm/tree/master/docs/chart_best_practices

Following best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Litmus is making use of [Scarf](https://docs.scarf.sh/) to obtain usage stats (via the docker images) to measure the adoption of the project. This requires adding the scarf gateway prefix to the images in the deployment specs. This PR instruments the Litmus Helm charts with the same. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] DCO signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
