### PR TITLE
Litmus Agent: allow using existing configuration and secrets

### DIFF
--- a/charts/litmus-agent/Chart.yaml
+++ b/charts/litmus-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.8.0"
 description: A Helm chart to install litmus agent
 name: litmus-agent
-version: 3.8.1
+version: 3.8.2
 kubeVersion: ">=1.16.0-0"
 home: https://litmuschaos.io
 sources:

--- a/charts/litmus-agent/README.md
+++ b/charts/litmus-agent/README.md
@@ -1,6 +1,6 @@
 # litmus-agent
 
-![Version: 3.8.1](https://img.shields.io/badge/Version-3.8.1-informational?style=flat-square) ![AppVersion: 3.8.0](https://img.shields.io/badge/AppVersion-3.8.0-informational?style=flat-square)
+![Version: 3.8.2](https://img.shields.io/badge/Version-3.8.2-informational?style=flat-square) ![AppVersion: 3.8.0](https://img.shields.io/badge/AppVersion-3.8.0-informational?style=flat-square)
 
 A Helm chart to install litmus agent
 
@@ -85,6 +85,10 @@ $ helm install litmus-agent litmuschaos/litmus-agent \
 | resources.requests.cpu | string | `"100m"` |  |
 | resources.requests.memory | string | `"128Mi"` |  |
 | subscriber.enabled | bool | `true` |  |
+| useExistingHookSecret | bool | `false` | Use an existing hook Secret instead of creating one with the chart, ref. to templates/secret.yaml |
+| useExistingInfraConfigMap | bool | `false` | Use an existing infra ConfigMap instead of creating one with the chart, ref. to templates/infra-config-map.yaml |
+| useExistingInfraSecret | bool | `false` | Use an existing infra Secret instead of creating one with the chart, ref. to templates/infra-secret.yaml |
+| useExistingWorkflowControllerConfigMap | bool | `false` | Use an existing infra ConfigMap instead of creating one with the chart, ref. to templates/infra-config-map-workflow.yaml |
 | workflow-controller.crds.create | bool | `true` |  |
 | workflow-controller.enabled | bool | `true` |  |
 

--- a/charts/litmus-agent/templates/infra-config-map-workflow.yaml
+++ b/charts/litmus-agent/templates/infra-config-map-workflow.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.useExistingWorkflowControllerConfigMap }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,3 +12,4 @@ metadata:
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-failed
 data: {}
+{{ end }}

--- a/charts/litmus-agent/templates/infra-config-map.yaml
+++ b/charts/litmus-agent/templates/infra-config-map.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.useExistingInfraConfigMap }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,3 +12,4 @@ metadata:
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-failed
 data: {}
+{{ end }}

--- a/charts/litmus-agent/templates/infra-secret.yaml
+++ b/charts/litmus-agent/templates/infra-secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.useExistingInfraSecret }}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -12,3 +13,4 @@ metadata:
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-failed
 data: {}
+{{ end }}

--- a/charts/litmus-agent/templates/secret.yaml
+++ b/charts/litmus-agent/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.useExistingHookSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -22,3 +23,4 @@ data:
   {{- if .Values.LITMUS_PROJECT_ID }}
   LITMUS_PROJECT_ID: {{ .Values.LITMUS_PROJECT_ID | b64enc | quote }}
   {{ end }}
+{{ end }}

--- a/charts/litmus-agent/values.yaml
+++ b/charts/litmus-agent/values.yaml
@@ -48,6 +48,27 @@ resources:
     cpu: 100m
     memory: 128Mi
 
+# Existing Secret name should be:
+# `{{ include "subscriber.fullname" . }}-hook`
+# I.E. `name: litmus-agent-hook`
+# -- Use an existing hook Secret instead of creating one with the chart, ref. to templates/secret.yaml
+useExistingHookSecret: false
+
+# Existing ConfigMap name should be equal to .global.infraConfigName
+# I.E. `name: subscriber-config`
+# -- Use an existing infra ConfigMap instead of creating one with the chart, ref. to templates/infra-config-map.yaml
+useExistingInfraConfigMap: false
+
+# Existing Secret name should be equal to .global.infraSecretName
+# I.E. `name: subscriber-secret`
+# -- Use an existing infra Secret instead of creating one with the chart, ref. to templates/infra-secret.yaml
+useExistingInfraSecret: false
+
+# Existing ConfigMap name should be:
+# `{{ index .Values "workflow-controller" "appSettings" "configmapName" }}`
+# -- Use an existing infra ConfigMap instead of creating one with the chart, ref. to templates/infra-config-map-workflow.yaml
+useExistingWorkflowControllerConfigMap: false
+
 chaos-operator:
   enabled: true
 


### PR DESCRIPTION
#### What this PR does / why we need it:

When using the Litmus Agent chart, we can set `global.infraConfigName` and `global.infraSecretName` but we can't use an existing (already in cluster) config or secret.

#### Which issue this PR fixes

  - fixes #311

#### Special notes for your reviewer:

This is a rework of https://github.com/litmuschaos/litmus-helm/pull/313 with the addition of the ability to use an existing `ConfigMap`.

#### Checklist

- [x] DCO signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
