### PR TITLE
fix: Use bitnami/os-shell instead of removed bitnami-shell in mongo

### DIFF
--- a/charts/litmus/Chart.yaml
+++ b/charts/litmus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.19.0"
 description: A Helm chart to install ChaosCenter
 name: litmus
-version: 3.19.0
+version: 3.19.1
 kubeVersion: ">=1.16.0-0"
 home: https://litmuschaos.io
 sources:

--- a/charts/litmus/README.md
+++ b/charts/litmus/README.md
@@ -1,6 +1,6 @@
 # litmus
 
-![Version: 3.19.0](https://img.shields.io/badge/Version-3.19.0-informational?style=flat-square) ![AppVersion: 3.19.0](https://img.shields.io/badge/AppVersion-3.19.0-informational?style=flat-square)
+![Version: 3.19.1](https://img.shields.io/badge/Version-3.19.1-informational?style=flat-square) ![AppVersion: 3.19.0](https://img.shields.io/badge/AppVersion-3.19.0-informational?style=flat-square)
 
 A Helm chart to install ChaosCenter
 
@@ -88,7 +88,7 @@ We separated service configuration from `portal.server.service` to `portal.serve
 | internalTLS.web.crt | string | `""` |  |
 | internalTLS.web.key | string | `""` |  |
 | internalTLS.web.secretName | string | `""` |  |
-| mongodb | object | `{"architecture":"replicaset","auth":{"enabled":true,"existingSecret":"","rootPassword":"1234","rootUser":"root"},"enabled":true,"livenessProbe":{"timeoutSeconds":20},"metrics":{"enabled":false,"prometheusRule":{"enabled":false}},"persistence":{"enabled":true},"readinessProbe":{"timeoutSeconds":20},"replicaCount":3,"volumePermissions":{"enabled":true}}` | Configure the Bitnami MongoDB subchart see values at https://github.com/bitnami/charts/blob/master/bitnami/mongodb/values.yaml |
+| mongodb | object | `{"architecture":"replicaset","auth":{"enabled":true,"existingSecret":"","rootPassword":"1234","rootUser":"root"},"enabled":true,"livenessProbe":{"timeoutSeconds":20},"metrics":{"enabled":false,"prometheusRule":{"enabled":false}},"persistence":{"enabled":true},"readinessProbe":{"timeoutSeconds":20},"replicaCount":3,"volumePermissions":{"enabled":true,"image":{"registry":"docker.io","repository":"bitnami/os-shell","tag":"12-debian-12-r47"}}}` | Configure the Bitnami MongoDB subchart see values at https://github.com/bitnami/charts/blob/master/bitnami/mongodb/values.yaml |
 | mongodb.auth.existingSecret | string | `""` | existingSecret Existing secret with MongoDB(&reg;) credentials (keys: `mongodb-passwords`, `mongodb-root-password`, `mongodb-metrics-password`, ` mongodb-replica-set-key`) |
 | nameOverride | string | `""` |  |
 | openshift.route.annotations | object | `{}` |  |

--- a/charts/litmus/values.yaml
+++ b/charts/litmus/values.yaml
@@ -380,6 +380,10 @@ mongodb:
     enabled: true
   volumePermissions:
     enabled: true
+    image:
+      registry: docker.io
+      repository: bitnami/os-shell
+      tag: 12-debian-12-r47
   metrics:
     enabled: false
     prometheusRule:


### PR DESCRIPTION
<!--

* https://github.com/helm/helm/tree/master/docs/chart_best_practices

Following best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

After installing the helm chart, mongodb pod is getting into ImagePullBackOff with `failed to resolve reference "docker.io/bitnami/bitnami-shell:10-debian-10-r431": docker.io/bitnami/bitnami-shell:10-debian-10-r431: not found`. 
#442 was created by a person that stumbled upon this issue, they mentioned updating values.yaml and decided to close their own issue. As this requires fetching and modifying the local chart, this PR updates the default values.yaml.

mentioning @imrajdas, @ispeakc0de and @jasstkn 

##### Context

`bitnami-shell` got deprecated and replaced by `os-shell`. Bitnami decided to pull `bitnami-shell` altogether from `docker.io`: https://github.com/bitnami/charts/issues/23406#issuecomment-1939805142 

Although the upstream mongodb chart has already updated the dependencies, Litmus uses the mongodb-1.12.11 chart. #423 is there for a longer term fix, but this should unblock installing the helm chart.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

#### Special notes for your reviewer:

#### Checklist
- [x] DCO signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
