### PR TITLE
feat(litmus-agent) : Make ChaosCenter pre-install registration optional

### DIFF
--- a/charts/litmus-agent/Chart.yaml
+++ b/charts/litmus-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.21.0"
 description: A Helm chart to install litmus agent
 name: litmus-agent
-version: 3.21.0
+version: 3.21.1
 kubeVersion: ">=1.16.0-0"
 home: https://litmuschaos.io
 sources:

--- a/charts/litmus-agent/README.md
+++ b/charts/litmus-agent/README.md
@@ -1,6 +1,6 @@
 # litmus-agent
 
-![Version: 3.21.0](https://img.shields.io/badge/Version-3.21.0-informational?style=flat-square) ![AppVersion: 3.21.0](https://img.shields.io/badge/AppVersion-3.21.0-informational?style=flat-square)
+![Version: 3.21.1](https://img.shields.io/badge/Version-3.21.1-informational?style=flat-square) ![AppVersion: 3.21.0](https://img.shields.io/badge/AppVersion-3.21.0-informational?style=flat-square)
 
 A Helm chart to install litmus agent
 
@@ -71,6 +71,7 @@ $ helm install litmus-agent litmuschaos/litmus-agent \
 | chaos-exporter.enabled | bool | `true` |  |
 | chaos-operator.enabled | bool | `true` |  |
 | crds.create | bool | `true` |  |
+| enablePreInstallJob | bool | `true` | Enable the pre-install hook job that registers this agent with ChaosCenter. Set to false for standallone litmus-agent installation (no ChaosCenter) however other ChaosCenter resources (e.g., hook Secrets/ConfigMaps) may still be rendered; manage them via their own flags (e.g., useExistingHookSecret). |
 | event-tracker.enabled | bool | `true` |  |
 | global.INFRA_MODE | string | `"cluster"` |  |
 | global.customLabels | object | `{}` |  |

--- a/charts/litmus-agent/templates/hook-pre-install-job.yaml
+++ b/charts/litmus-agent/templates/hook-pre-install-job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enablePreInstallJob }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -83,3 +84,4 @@ spec:
 
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
+{{end}}

--- a/charts/litmus-agent/values.yaml
+++ b/charts/litmus-agent/values.yaml
@@ -50,6 +50,11 @@ resources:
     cpu: 100m
     memory: 128Mi
 
+# -- Enable the pre-install hook job that registers this agent with ChaosCenter.
+# Set to false for standallone litmus-agent installation (no ChaosCenter) however other ChaosCenter resources (e.g., hook Secrets/ConfigMaps) may still be rendered;
+# manage them via their own flags (e.g., useExistingHookSecret).
+enablePreInstallJob: true
+
 # Existing Secret name should be:
 # `{{ include "subscriber.fullname" . }}-hook`
 # I.E. `name: litmus-agent-hook`


### PR DESCRIPTION
#### What this PR does :
This PR introduces enablePreInstallJob (default: true) to the litmus-agent Helm chart, making the ChaosCenter registration pre-install hook Job optional. When set to false, the chart installs in standalone mode without attempting to call back to ChaosCenter.

#### why we need it:
Some environments (e.g., air-gapped, restricted outbound) cannot or should not attempt registration with ChaosCenter.
Users running agent-only workflows (triggered externally via Argo Workflows, etc.) need a simple, out-of-the-box way to skip the registration hook.

#### Changes
- Add enablePreInstallJob to values.yaml (default: true)
- Wrap the pre-install Job manifest in a conditional:
     - When true: render Job with helm.sh/hook: pre-install
     - When false: skip Job entirely
- Update README 

#### Backward compatibility
Default behavior unchanged: the Job still renders and runs when enablePreInstallJob=true
No breaking changes to existing users

#### Testing
- Verified via `helm template` that setting `enablePreInstallJob=false` skips Job creation.
- Default behavior (true) still creates the Job.

#### Limitations / Notes
- Other ChaosCenter-related resources (e.g., hook Secrets/ConfigMaps) may still be rendered; control them via existing flags (e.g., useExistingHookSecret)
- This PR does not remove or change any other ChaosCenter integration logic

#### Which issue this PR fixes
  - fixes #444 


#### Checklist
- [ ] DCO signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md