### PR TITLE
feat(litmus): add option to skip wait-for-mongodb initContainer (#469)

### DIFF
--- a/charts/litmus/templates/auth-server-deployment.yaml
+++ b/charts/litmus/templates/auth-server-deployment.yaml
@@ -38,6 +38,7 @@ spec:
       imagePullSecrets:
         {{ toYaml .Values.image.imagePullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.portal.server.waitForMongodb.enabled }}
       initContainers:
         - name: wait-for-mongodb
           image: {{ .Values.image.imageRegistryName }}/{{ .Values.portal.server.waitForMongodb.image.repository }}:{{ .Values.portal.server.waitForMongodb.image.tag }}
@@ -82,6 +83,7 @@ spec:
             {{- toYaml .Values.portal.server.waitForMongodb.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.portal.server.waitForMongodb.securityContext | nindent 12 }}
+      {{- end }}
       containers:
         - name: auth-server
           image: {{ .Values.image.imageRegistryName }}/{{ .Values.portal.server.authServer.image.repository }}:{{ .Values.portal.server.authServer.image.tag }}

--- a/charts/litmus/templates/server-deployment.yaml
+++ b/charts/litmus/templates/server-deployment.yaml
@@ -43,6 +43,7 @@ spec:
           secret:
             secretName: {{ template "litmus-portal.internalTLS.graphqlServer.secretName" . }}
         {{- end }}
+      {{- if .Values.portal.server.waitForMongodb.enabled }}
       initContainers:
         - name: wait-for-mongodb
           image: {{ .Values.image.imageRegistryName }}/{{ .Values.portal.server.waitForMongodb.image.repository }}:{{ .Values.portal.server.waitForMongodb.image.tag }}
@@ -87,6 +88,7 @@ spec:
             {{- toYaml .Values.portal.server.waitForMongodb.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.portal.server.waitForMongodb.securityContext | nindent 12 }}
+      {{- end }}
       containers:
         - name: graphql-server
           image: {{ .Values.image.imageRegistryName }}/{{ .Values.portal.server.graphqlServer.image.repository }}:{{ .Values.portal.server.graphqlServer.image.tag }}

--- a/charts/litmus/values.yaml
+++ b/charts/litmus/values.yaml
@@ -190,6 +190,8 @@ portal:
     customLabels: {}
     # my.company.com/tier: "backend"
     waitForMongodb:
+      # -- Set to false to skip the wait-for-mongodb initContainer when using external MongoDB
+      enabled: true
       image:
         repository: mongo
         tag: 6


### PR DESCRIPTION
<!--

* https://github.com/helm/helm/tree/master/docs/chart_best_practices

Following best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->


Add portal.server.waitForMongodb.enabled flag to allow users to skip
the wait-for-mongodb initContainer when using external MongoDB that is
already running.




#### What this PR does / why we need it:

This resolves issues in air-gapped environments and reduces deployment
time when MongoDB is already accessible.

#### Which issue this PR fixes
  - fixes #469

#### Special notes for your reviewer:

@imrajdas @ispeakc0de @jasstkn Need your feedback and guide for this PR, I do not know much the impact on the existing please let me know anything to enhance 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] DCO signed
- [ ] Variables are documented in the README.md
