### PR TITLE
feat(litmus): add extraEnvVars to portal components

### DIFF
--- a/charts/litmus/Chart.yaml
+++ b/charts/litmus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.24.0"
 description: A Helm chart to install ChaosCenter
 name: litmus
-version: 3.24.0
+version: 3.24.1
 kubeVersion: ">=1.16.0-0"
 home: https://litmuschaos.io
 sources:

--- a/charts/litmus/README.md
+++ b/charts/litmus/README.md
@@ -1,6 +1,6 @@
 # litmus
 
-![Version: 3.24.0](https://img.shields.io/badge/Version-3.24.0-informational?style=flat-square) ![AppVersion: 3.24.0](https://img.shields.io/badge/AppVersion-3.24.0-informational?style=flat-square)
+![Version: 3.24.1](https://img.shields.io/badge/Version-3.24.1-informational?style=flat-square) ![AppVersion: 3.24.0](https://img.shields.io/badge/AppVersion-3.24.0-informational?style=flat-square)
 
 A Helm chart to install ChaosCenter
 
@@ -105,6 +105,7 @@ We separated service configuration from `portal.server.service` to `portal.serve
 | portal.frontend.autoscaling.targetMemoryUtilizationPercentage | int | `50` |  |
 | portal.frontend.containerPort | int | `8185` |  |
 | portal.frontend.customLabels | object | `{}` |  |
+| portal.frontend.extraEnvVars | list | `[]` | Additional environment variables for frontend container |
 | portal.frontend.image.pullPolicy | string | `"Always"` |  |
 | portal.frontend.image.repository | string | `"litmusportal-frontend"` |  |
 | portal.frontend.image.tag | string | `"3.24.0"` |  |
@@ -172,6 +173,7 @@ We separated service configuration from `portal.server.service` to `portal.serve
 | portal.server.authServer.volumeMounts | list | `[]` |  |
 | portal.server.authServer.volumes | list | `[]` |  |
 | portal.server.customLabels | object | `{}` |  |
+| portal.server.extraEnvVars | list | `[]` | Additional environment variables for graphql-server container |
 | portal.server.graphqlServer.automountServiceAccountToken | bool | `false` |  |
 | portal.server.graphqlServer.genericEnv.CHAOS_CENTER_UI_ENDPOINT | string | `""` |  |
 | portal.server.graphqlServer.genericEnv.CONTAINER_RUNTIME_EXECUTOR | string | `"k8sapi"` |  |

--- a/charts/litmus/templates/frontend-deployment.yaml
+++ b/charts/litmus/templates/frontend-deployment.yaml
@@ -70,6 +70,10 @@ spec:
           ports:
             - containerPort: {{ .Values.portal.frontend.containerPort }}
               name: http
+          {{- if .Values.portal.frontend.extraEnvVars }}
+          env:
+            {{- toYaml .Values.portal.frontend.extraEnvVars | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: nginx-config
               mountPath: /etc/nginx/nginx.conf

--- a/charts/litmus/templates/server-deployment.yaml
+++ b/charts/litmus/templates/server-deployment.yaml
@@ -174,6 +174,9 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end }}
+            {{- if .Values.portal.server.extraEnvVars }}
+            {{- toYaml .Values.portal.server.extraEnvVars | nindent 12 }}
+            {{- end }}
     {{- with .Values.portal.server.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/litmus/values.yaml
+++ b/charts/litmus/values.yaml
@@ -171,6 +171,10 @@ portal:
       hosts: []
       gateways: []
       pathPrefixEnabled: false
+    # -- Additional environment variables for frontend container
+    extraEnvVars: []
+    # - name: MY_ENV_VAR
+    #   value: "my-value"
     nodeSelector: {}
     tolerations: []
     affinity: {}
@@ -341,6 +345,10 @@ portal:
       volumeMounts: []
       volumes: []
       podAnnotations: {}
+    # -- Additional environment variables for graphql-server container
+    extraEnvVars: []
+    # - name: MY_ENV_VAR
+    #   value: "my-value"
     nodeSelector: {}
     tolerations: []
     affinity: {}


### PR DESCRIPTION
<!--

* https://github.com/helm/helm/tree/master/docs/chart_best_practices

Following best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Adds `extraEnvVars` configuration option to both `portal.frontend` and `portal.server` components, allowing users to inject custom environment variables into the frontend and GraphQL server containers without modifying the Helm chart templates directly.

This provides a flexible way to configure additional environment variables for specific deployment requirements, such as setting `SSH_KNOWN_HOSTS` for Gitops or other custom configuration needs.


#### Special notes for your reviewer:

- The implementation follows the same pattern used in other Helm charts for `extraEnvVars`


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] DCO signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

@Jonsy13 