### PR TITLE
fix: add missing `litmuschaos.io/app` label to agent charts

### DIFF
--- a/charts/litmus-agent/charts/chaos-exporter/templates/_helpers.tpl
+++ b/charts/litmus-agent/charts/chaos-exporter/templates/_helpers.tpl
@@ -52,6 +52,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "chaos-exporter.selectorLabels" -}}
+litmuschaos.io/app: {{ .Chart.Name }}
 app.kubernetes.io/name: {{ include "chaos-exporter.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app: {{ .Chart.Name }}

--- a/charts/litmus-agent/charts/chaos-operator/templates/_helpers.tpl
+++ b/charts/litmus-agent/charts/chaos-operator/templates/_helpers.tpl
@@ -52,6 +52,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "chaos-operator.selectorLabels" -}}
+litmuschaos.io/app: {{ .Chart.Name }}
 name: {{ .Chart.Name }}
 app.kubernetes.io/name: {{ include "chaos-operator.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/litmus-agent/charts/event-tracker/templates/_helpers.tpl
+++ b/charts/litmus-agent/charts/event-tracker/templates/_helpers.tpl
@@ -52,6 +52,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "event-tracker.selectorLabels" -}}
+litmuschaos.io/app: {{ .Chart.Name }}
 app: {{ .Chart.Name }}
 app.kubernetes.io/name: {{ include "event-tracker.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/litmus-agent/charts/workflow-controller/templates/_helpers.tpl
+++ b/charts/litmus-agent/charts/workflow-controller/templates/_helpers.tpl
@@ -52,6 +52,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "workflow-controller.selectorLabels" -}}
+litmuschaos.io/app: {{ .Chart.Name }}
 app: {{ .Chart.Name }}
 app.kubernetes.io/name: {{ include "workflow-controller.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds the missing `litmuschoas.io/app` label to the selectorLabels template in the agent charts (`chaos-exporter`, `chaos-operator`, `event-tracker`, `workflow-controller`)

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #467 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] DCO signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
