### PR TITLE
feat(workflow-controller): make log level configurable

### DIFF
--- a/charts/litmus-agent/Chart.yaml
+++ b/charts/litmus-agent/Chart.yaml
@@ -33,5 +33,5 @@ dependencies:
     version: 3.24.0
     condition: subscriber.enabled
   - name: workflow-controller
-    version: 0.2.2
+    version: 0.2.3
     condition: workflow-controller.enabled

--- a/charts/litmus-agent/README.md
+++ b/charts/litmus-agent/README.md
@@ -28,7 +28,7 @@ Kubernetes: `>=1.16.0-0`
 |  | chaos-operator | 3.24.0 |
 |  | event-tracker | 3.24.0 |
 |  | subscriber | 3.24.0 |
-|  | workflow-controller | 0.2.2 |
+|  | workflow-controller | 0.2.3 |
 
 ## Installing the Chart
 

--- a/charts/litmus-agent/charts/workflow-controller/Chart.yaml
+++ b/charts/litmus-agent/charts/workflow-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v3.3.1"
 description:  A Helm chart to install workflow-controller
 name: workflow-controller
-version: 0.2.2
+version: 0.2.3
 kubeVersion: ">=1.16.0-0"
 home: https://litmuschaos.io
 sources:

--- a/charts/litmus-agent/charts/workflow-controller/README.md
+++ b/charts/litmus-agent/charts/workflow-controller/README.md
@@ -1,6 +1,6 @@
 # workflow-controller
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![AppVersion: v3.3.1](https://img.shields.io/badge/AppVersion-v3.3.1-informational?style=flat-square)
+![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![AppVersion: v3.3.1](https://img.shields.io/badge/AppVersion-v3.3.1-informational?style=flat-square)
 
 A Helm chart to install workflow-controller
 
@@ -30,6 +30,7 @@ Kubernetes: `>=1.16.0-0`
 | appSettings.configmapName | string | `"workflow-controller-configmap"` |  |
 | appSettings.containerRuntimeExecutor | string | `"k8sapi"` |  |
 | appSettings.executorImage | string | `"litmuschaos/argoexec:v3.3.1"` |  |
+| appSettings.loglevel | string | `"debug"` |  |
 | autoscaling.enabled | bool | `false` |  |
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |

--- a/charts/litmus-agent/charts/workflow-controller/README.md
+++ b/charts/litmus-agent/charts/workflow-controller/README.md
@@ -30,6 +30,7 @@ Kubernetes: `>=1.16.0-0`
 | appSettings.configmapName | string | `"workflow-controller-configmap"` |  |
 | appSettings.containerRuntimeExecutor | string | `"k8sapi"` |  |
 | appSettings.executorImage | string | `"litmuschaos/argoexec:v3.3.1"` |  |
+| appSettings.gloglevel | string | `"1"` |  |
 | appSettings.loglevel | string | `"debug"` |  |
 | autoscaling.enabled | bool | `false` |  |
 | autoscaling.maxReplicas | int | `100` |  |

--- a/charts/litmus-agent/charts/workflow-controller/templates/deployment.yaml
+++ b/charts/litmus-agent/charts/workflow-controller/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
             - --container-runtime-executor
             - {{ .Values.appSettings.containerRuntimeExecutor }}
             - --loglevel
-            - debug
+            - {{ .Values.appSettings.loglevel }}
             - --gloglevel
             - "1"
           command:

--- a/charts/litmus-agent/charts/workflow-controller/templates/deployment.yaml
+++ b/charts/litmus-agent/charts/workflow-controller/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
             - --loglevel
             - {{ .Values.appSettings.loglevel }}
             - --gloglevel
-            - "1"
+            - {{ .Values.appSettings.gloglevel | quote }}
           command:
             - workflow-controller
           env:

--- a/charts/litmus-agent/charts/workflow-controller/values.yaml
+++ b/charts/litmus-agent/charts/workflow-controller/values.yaml
@@ -6,6 +6,7 @@ appSettings:
   configmapName: "workflow-controller-configmap"
   executorImage: "litmuschaos/argoexec:v3.3.1"
   containerRuntimeExecutor: "k8sapi"
+  loglevel: "debug"
 
 crds:
   create: true

--- a/charts/litmus-agent/charts/workflow-controller/values.yaml
+++ b/charts/litmus-agent/charts/workflow-controller/values.yaml
@@ -7,6 +7,7 @@ appSettings:
   executorImage: "litmuschaos/argoexec:v3.3.1"
   containerRuntimeExecutor: "k8sapi"
   loglevel: "debug"
+  gloglevel: "1"
 
 crds:
   create: true


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds the ability to override the workflow-controller **log level** and **glog verbosity** via Helm values. Today `--loglevel` is hardcoded to `debug` and `--gloglevel` to `"1"` in the Deployment, so operators cannot reduce log volume without forking or post-rendering.

In multi-cluster setups (e.g. 20+ clusters), the **litmus-agent-workflow-controller** at debug generates a large amount of logs (e.g. 30k+ records per 15 minutes), increasing ingestion and storage cost. This change adds:

- **`appSettings.loglevel`** (default: `debug`, for compatibility) — controls the application log level (debug, info, warn, error). Installers can set e.g. `workflow-controller.appSettings.loglevel: "info"` to cut debug noise.
- **`appSettings.gloglevel`** (default: `"1"`, for compatibility) — controls glog verbosity (numeric; higher = more verbose). Installers can set e.g. `workflow-controller.appSettings.gloglevel: "0"` to reduce glog output.

Both keep existing behavior by default so the chart remains backward compatible.

#### Which issue this PR fixes

fixes #474

#### Special notes for your reviewer:

- Defaults remain `loglevel: debug` and `gloglevel: "1"` for backward compatibility.
- Only the workflow-controller subchart was changed; chart version bumped 0.2.2 → 0.2.3 (patch).
- `litmus-agent/Chart.yaml` dependency on workflow-controller updated to 0.2.3.

#### Checklist

- [x] DCO signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

---

@Vr00mm @ispeakc0de @Jonsy13 