### PR TITLE
fix(litmus-agent): fix hook secret name mismatch and subscriber subchart dependency

### DIFF
--- a/charts/litmus-agent/templates/infra-config-map-workflow.yaml
+++ b/charts/litmus-agent/templates/infra-config-map-workflow.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ index .Values "workflow-controller" "appSettings" "configmapName" }}
   labels:
-    {{- include "subscriber.labels" . | nindent 4 }}
+    {{- include "litmus-agent.labels" . | nindent 4 }}
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.

--- a/charts/litmus-agent/templates/infra-config-map.yaml
+++ b/charts/litmus-agent/templates/infra-config-map.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ .Values.global.infraConfigName }}
   labels:
-    {{- include "subscriber.labels" . | nindent 4 }}
+    {{- include "litmus-agent.labels" . | nindent 4 }}
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.

--- a/charts/litmus-agent/templates/infra-secret.yaml
+++ b/charts/litmus-agent/templates/infra-secret.yaml
@@ -5,7 +5,7 @@ type: Opaque
 metadata:
   name: {{ .Values.global.infraSecretName }}
   labels:
-    {{- include "subscriber.labels" . | nindent 4 }}
+    {{- include "litmus-agent.labels" . | nindent 4 }}
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.

--- a/charts/litmus-agent/templates/secret.yaml
+++ b/charts/litmus-agent/templates/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "subscriber.fullname" . }}-hook
+  name: {{ include "litmus-agent.fullname" . }}-hook
   labels:
     {{- include "litmus-agent.labels" . | nindent 4 }}
   annotations:

--- a/charts/litmus-agent/values.yaml
+++ b/charts/litmus-agent/values.yaml
@@ -56,7 +56,7 @@ resources:
 enablePreInstallJob: true
 
 # Existing Secret name should be:
-# `{{ include "subscriber.fullname" . }}-hook`
+# `{{ include "litmus-agent.fullname" . }}-hook`
 # I.E. `name: litmus-agent-hook`
 # -- Use an existing hook Secret instead of creating one with the chart, ref. to templates/secret.yaml
 useExistingHookSecret: false


### PR DESCRIPTION
## Summary

- Replace all `subscriber.*` template helper references in parent chart templates with `litmus-agent.*` equivalents
- Fix hook secret name mismatch between creation (`subscriber.fullname`) and reference (`litmus-agent.fullname`)
- Fix chart rendering failure when `subscriber.enabled: false`
- Update `values.yaml` comment to reference the correct helper

## Problem

The `litmus-agent` parent chart was using helper templates defined in the `subscriber` subchart:

| File | Was using | Now uses |
|------|-----------|----------|
| `templates/secret.yaml` | `subscriber.fullname` | `litmus-agent.fullname` |
| `templates/infra-secret.yaml` | `subscriber.labels` | `litmus-agent.labels` |
| `templates/infra-config-map.yaml` | `subscriber.labels` | `litmus-agent.labels` |
| `templates/infra-config-map-workflow.yaml` | `subscriber.labels` | `litmus-agent.labels` |

This caused:
1. **Secret name mismatch** — the hook secret was created as `<release>-subscriber-hook` but the pre-install job referenced `<release>-litmus-agent-hook`
2. **Render failure** — setting `subscriber.enabled: false` caused `helm template` to fail because the subscriber subchart's `_helpers.tpl` was not loaded

## Verification

```bash
# Both pass after the fix:
helm template test-release charts/litmus-agent
helm template test-release charts/litmus-agent --set subscriber.enabled=false
```

Closes #418

## Test plan

- [x] `helm template` succeeds with default values
- [x] `helm template` succeeds with `subscriber.enabled=false`
- [x] Hook secret name matches between `secret.yaml` and `hook-pre-install-job.yaml`