### PR TITLE
fix(litmus-agent): render preinstall RBAC only when preinstall job is true

### DIFF
--- a/charts/litmus-agent/Chart.yaml
+++ b/charts/litmus-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.29.0"
 description: A Helm chart to install litmus agent
 name: litmus-agent
-version: 3.29.0
+version: 3.29.1
 kubeVersion: ">=1.16.0-0"
 home: https://litmuschaos.io
 sources:

--- a/charts/litmus-agent/README.md
+++ b/charts/litmus-agent/README.md
@@ -1,6 +1,6 @@
 # litmus-agent
 
-![Version: 3.29.0](https://img.shields.io/badge/Version-3.29.0-informational?style=flat-square) ![AppVersion: 3.29.0](https://img.shields.io/badge/AppVersion-3.29.0-informational?style=flat-square)
+![Version: 3.29.1](https://img.shields.io/badge/Version-3.29.1-informational?style=flat-square) ![AppVersion: 3.29.0](https://img.shields.io/badge/AppVersion-3.29.0-informational?style=flat-square)
 
 A Helm chart to install litmus agent
 

--- a/charts/litmus-agent/templates/serviceaccount.yaml
+++ b/charts/litmus-agent/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enablePreInstallJob }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -45,3 +46,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "litmus-agent.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+{{- end }}


### PR DESCRIPTION
This PR scopes the litmus-agent pre-install RBAC resources (ServiceAccount, Role, RoleBinding) to the same toggle as the pre-install registration job by wrapping them with enablePreInstallJob, 

so when the job is disabled these resources are not rendered, and when enabled (default behavior) the flow remains unchanged; this reduces unnecessary resource creation in standalone/no-ChaosCenter installs without altering the default install path.

Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

 DCO signed
 Chart Version bumped
 Variables are documented in the README.md