### PR TITLE
fix: sanitize app.kubernetes.io/version label for SemVer build metadata

### DIFF
--- a/charts/kube-aws/templates/_helpers.tpl
+++ b/charts/kube-aws/templates/_helpers.tpl
@@ -38,7 +38,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/name: {{ template "kube-aws.fullname" . }}
 app.kubernetes.io/part-of: {{ template "kube-aws.fullname" . }} 
-app.kubernetes.io/version: "{{ .Chart.Version }}"
+app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
 helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }} 
 litmuschaos.io/version: {{ .Chart.AppVersion }}
 {{- if .Values.customLabels }}

--- a/charts/kube-azure/templates/_helpers.tpl
+++ b/charts/kube-azure/templates/_helpers.tpl
@@ -38,7 +38,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/name: {{ template "kube-azure.fullname" . }}
 app.kubernetes.io/part-of: {{ template "kube-azure.fullname" . }} 
-app.kubernetes.io/version: "{{ .Chart.Version }}"
+app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
 helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }} 
 litmuschaos.io/version: {{ .Chart.AppVersion }}
 {{- if .Values.customLabels }}

--- a/charts/kube-gcp/templates/_helpers.tpl
+++ b/charts/kube-gcp/templates/_helpers.tpl
@@ -38,7 +38,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/name: {{ template "kube-gcp.fullname" . }}
 app.kubernetes.io/part-of: {{ template "kube-gcp.fullname" . }} 
-app.kubernetes.io/version: "{{ .Chart.Version }}"
+app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
 helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }} 
 litmuschaos.io/version: {{ .Chart.AppVersion }}
 {{- if .Values.customLabels }}

--- a/charts/kubernetes-chaos/templates/_helpers.tpl
+++ b/charts/kubernetes-chaos/templates/_helpers.tpl
@@ -38,7 +38,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/name: {{ template "kubernetes-chaos.fullname" . }}
 app.kubernetes.io/part-of: {{ template "kubernetes-chaos.fullname" . }} 
-app.kubernetes.io/version: "{{ .Chart.Version }}"
+app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
 helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }} 
 litmuschaos.io/version: {{ .Chart.AppVersion }}
 {{- if .Values.customLabels }}

--- a/charts/litmus-core/templates/_helpers.tpl
+++ b/charts/litmus-core/templates/_helpers.tpl
@@ -38,7 +38,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/name: {{ template "litmus.name" . }}
 app.kubernetes.io/part-of: {{ template "litmus.name" . }} 
-app.kubernetes.io/version: "{{ .Chart.Version }}"
+app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
 helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }} 
 litmuschaos.io/version: {{ .Chart.AppVersion }}
 {{- if .Values.customLabels }}

--- a/charts/litmus/templates/_helpers.tpl
+++ b/charts/litmus/templates/_helpers.tpl
@@ -39,7 +39,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/name: {{ include "litmus-portal.name" . }}
 app.kubernetes.io/part-of: {{ template "litmus-portal.name" . }}
-app.kubernetes.io/version: "{{ .Chart.Version }}"
+app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}"
 helm.sh/chart: {{ include "litmus-portal.chart" . }}
 litmuschaos.io/version: {{ .Chart.AppVersion }}
 {{- if .Values.customLabels }}


### PR DESCRIPTION
## What this PR does

Fixes litmuschaos/litmus#5613.

`app.kubernetes.io/version` renders `.Chart.Version` verbatim in the label helpers. Kubernetes label values must match `(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?` and cannot contain `+`. When tooling appends SemVer build metadata to the chart version (for example `3.30.0+build.5`), every templated resource is rejected by the API server.

This PR sanitizes the label value the same way the existing `litmus-portal.chart` helper already does: replace `+` with `_`, truncate to 63 characters, and trim a trailing `-`.

Before:

```
app.kubernetes.io/version: "3.30.0+build.5"   # rejected by the API server
```

After:

```
app.kubernetes.io/version: "3.30.0_build.5"
```

Applied to all charts whose label helper uses `.Chart.Version`:

- litmus
- litmus-core
- kubernetes-chaos
- kube-aws
- kube-azure
- kube-gcp

The `litmus-agent` charts use `.Chart.AppVersion` and were left unchanged.

## Verification

- Rendered the `litmus` chart with `version: 3.30.0+build.5` in Chart.yaml: the label now renders as `3.30.0_build.5` and matches the Kubernetes label value regex.
- `helm lint` passes for all six modified charts.
- `helm template` renders successfully for all six charts.
